### PR TITLE
feat: adds models for video engagement reports (FC-0024)

### DIFF
--- a/.github/workflows/add-depr-ticket-to-depr-board.yml
+++ b/.github/workflows/add-depr-ticket-to-depr-board.yml
@@ -1,0 +1,19 @@
+# Run the workflow that adds new tickets that are either:
+# - labelled "DEPR"
+# - title starts with "[DEPR]"
+# - body starts with "Proposal Date" (this is the first template field)
+# to the org-wide DEPR project board
+
+name: Add newly created DEPR issues to the DEPR project board
+
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  routeissue:
+    uses: openedx/.github/.github/workflows/add-depr-ticket-to-depr-board.yml@master
+    secrets:
+      GITHUB_APP_ID: ${{ secrets.GRAPHQL_AUTH_APP_ID }}
+      GITHUB_APP_PRIVATE_KEY: ${{ secrets.GRAPHQL_AUTH_APP_PEM }}
+      SLACK_BOT_TOKEN: ${{ secrets.SLACK_ISSUE_BOT_TOKEN }}

--- a/.github/workflows/add-remove-label-on-comment.yml
+++ b/.github/workflows/add-remove-label-on-comment.yml
@@ -1,0 +1,20 @@
+# This workflow runs when a comment is made on the ticket
+# If the comment starts with "label: " it tries to apply
+# the label indicated in rest of comment.
+# If the comment starts with "remove label: ", it tries
+# to remove the indicated label.
+# Note: Labels are allowed to have spaces and this script does
+# not parse spaces (as often a space is legitimate), so the command
+# "label: really long lots of words label" will apply the
+# label "really long lots of words label"
+
+name: Allows for the adding and removing of labels via comment
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  add_remove_labels:
+    uses: openedx/.github/.github/workflows/add-remove-label-on-comment.yml@master
+

--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -1,0 +1,10 @@
+# Run commitlint on the commit messages in a pull request.
+
+name: Lint Commit Messages
+
+on:
+  - pull_request
+
+jobs:
+  commitlint:
+    uses: openedx/.github/.github/workflows/commitlint.yml@master

--- a/.github/workflows/self-assign-issue.yml
+++ b/.github/workflows/self-assign-issue.yml
@@ -1,0 +1,12 @@
+# This workflow runs when a comment is made on the ticket
+# If the comment starts with "assign me" it assigns the author to the
+# ticket (case insensitive)
+
+name: Assign comment author to ticket if they say "assign me"
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  self_assign_by_comment:
+    uses: openedx/.github/.github/workflows/self-assign-issue.yml@master

--- a/oars/models/base/sources.yml
+++ b/oars/models/base/sources.yml
@@ -30,7 +30,6 @@ sources:
           - name: course_id
           - name: org
           - name: verb_id
-          - name: event_type
           - name: enrollment_mode
 
       - name: video_playback_events
@@ -43,7 +42,6 @@ sources:
           - name: course_id
           - name: org
           - name: verb_id
-          - name: event_type
           - name: video_position
 
       - name: problem_events
@@ -56,7 +54,6 @@ sources:
           - name: course_id
           - name: org
           - name: verb_id
-          - name: event_type
           - name: responses
           - name: scaled_score
           - name: success

--- a/oars/models/base/sources.yml
+++ b/oars/models/base/sources.yml
@@ -32,3 +32,47 @@ sources:
           - name: verb_id
           - name: event_type
           - name: enrollment_mode
+
+      - name: video_playback_events
+        identifier: "{{ env_var('OARS_VIDEO_PLAYBACK_EVENTS_TABLE', 'video_playback_events') }}"
+        columns:
+          - name: event_id
+          - name: emission_time
+          - name: actor_id
+          - name: object_id
+          - name: course_id
+          - name: org
+          - name: verb_id
+          - name: event_type
+          - name: video_position
+
+      - name: problem_events
+        identifier: "{{ env_var('OARS_PROBLEM_EVENTS_TABLE', 'problem_events') }}"
+        columns:
+          - name: event_id
+          - name: emission_time
+          - name: actor_id
+          - name: object_id
+          - name: course_id
+          - name: org
+          - name: verb_id
+          - name: event_type
+          - name: responses
+          - name: scaled_score
+          - name: success
+          - name: interaction_type
+          - name: attempts
+
+      - name: navigation_events
+        identifier: "{{ env_var('OARS_NAVIGATION_EVENTS_TABLE', 'navigation_events') }}"
+        columns:
+          - name: event_id
+          - name: emission_time
+          - name: actor_id
+          - name: object_id
+          - name: course_id
+          - name: org
+          - name: verb_id
+          - name: object_type
+          - name: starting_position
+          - name: ending_point

--- a/oars/models/video/schema.yml
+++ b/oars/models/video/schema.yml
@@ -1,0 +1,20 @@
+version: 2
+
+models:
+  - name: video_plays
+    description: "One record for each time a learner played a video"
+    columns:
+      - name: emission_time
+      - name: org
+      - name: course_id
+      - name: video_id
+      - name: actor_id
+
+  - name: transcript_usage
+    description: "One record for each time a transcript of closed caption was enabled"
+    columns:
+      - name: emission_time
+      - name: org
+      - name: course_id
+      - name: video_id
+      - name: actor_id

--- a/oars/models/video/transcript_usage.sql
+++ b/oars/models/video/transcript_usage.sql
@@ -1,0 +1,11 @@
+select
+    emission_time,
+    org,
+    course_id,
+    splitByString('/xblock/', object_id)[2] as video_id,
+    actor_id
+from
+    {{ source('xapi', 'xapi_events_all_parsed') }}
+where
+    verb_id = 'http://adlnet.gov/expapi/verbs/interacted'
+    and JSON_VALUE(event_str, '$.result.extensions."https://w3id.org/xapi/video/extensions/cc-enabled"') = 'true'

--- a/oars/models/video/video_plays.sql
+++ b/oars/models/video/video_plays.sql
@@ -10,4 +10,4 @@ select
 from
     {{ source('xapi', 'video_playback_events') }}
 where
-    event_type = 'play'
+    event_type = 'played'

--- a/oars/models/video/video_plays.sql
+++ b/oars/models/video/video_plays.sql
@@ -10,4 +10,4 @@ select
 from
     {{ source('xapi', 'video_playback_events') }}
 where
-    event_type = 'played'
+    verb_id = 'https://w3id.org/xapi/video/verbs/played'

--- a/oars/models/video/video_plays.sql
+++ b/oars/models/video/video_plays.sql
@@ -1,0 +1,13 @@
+-- model to support number of watches per video
+-- ref: https://edx.readthedocs.io/projects/edx-insights/en/latest/Reference.html#engagement-computations
+
+select
+    emission_time,
+    org,
+    course_id,
+    splitByString('/xblock/', object_id)[2] as video_id,
+    actor_id
+from
+    {{ source('xapi', 'video_playback_events') }}
+where
+    event_type = 'play'


### PR DESCRIPTION
Adds two new models for issue #3 :
- `video_plays`: contains a record for each time a learner played a video. Can be used to generate reports of total plays and unique watchers
- `transcript_usage`: contains a record for each time a transcript or closed caption was enabled. Can be used to generate reports for total transcription/caption usage as well as the number of unique learners who enabled transcription/closed captioning

For each model, `org`, `course_id`, and `video_id` are available as dimensions.

**Question for reviewers:** is there a more robust way of deriving a video ID from the `object_id`? This approach works for test data but uses a relatively naive approach and may not accurately capture the video ID from different environments.

**Note:** this PR does not define the metrics available from these tables as they also need to be defined in Superset. I have Superset datasets (and an example chart) for each model and can export and share them if that's helpful.