### PR TITLE
feat: adds models for video engagement reports (FC-0024)

### DIFF
--- a/aspects/models/base/sources.yml
+++ b/aspects/models/base/sources.yml
@@ -31,3 +31,45 @@ sources:
           - name: org
           - name: verb_id
           - name: enrollment_mode
+
+      - name: video_playback_events
+        identifier: "{{ env_var('OARS_VIDEO_PLAYBACK_EVENTS_TABLE', 'video_playback_events') }}"
+        columns:
+          - name: event_id
+          - name: emission_time
+          - name: actor_id
+          - name: object_id
+          - name: course_id
+          - name: org
+          - name: verb_id
+          - name: video_position
+
+      - name: problem_events
+        identifier: "{{ env_var('OARS_PROBLEM_EVENTS_TABLE', 'problem_events') }}"
+        columns:
+          - name: event_id
+          - name: emission_time
+          - name: actor_id
+          - name: object_id
+          - name: course_id
+          - name: org
+          - name: verb_id
+          - name: responses
+          - name: scaled_score
+          - name: success
+          - name: interaction_type
+          - name: attempts
+
+      - name: navigation_events
+        identifier: "{{ env_var('OARS_NAVIGATION_EVENTS_TABLE', 'navigation_events') }}"
+        columns:
+          - name: event_id
+          - name: emission_time
+          - name: actor_id
+          - name: object_id
+          - name: course_id
+          - name: org
+          - name: verb_id
+          - name: object_type
+          - name: starting_position
+          - name: ending_point

--- a/aspects/models/video/schema.yml
+++ b/aspects/models/video/schema.yml
@@ -1,0 +1,20 @@
+version: 2
+
+models:
+  - name: video_plays
+    description: "One record for each time a learner played a video"
+    columns:
+      - name: emission_time
+      - name: org
+      - name: course_id
+      - name: video_id
+      - name: actor_id
+
+  - name: transcript_usage
+    description: "One record for each time a transcript of closed caption was enabled"
+    columns:
+      - name: emission_time
+      - name: org
+      - name: course_id
+      - name: video_id
+      - name: actor_id

--- a/aspects/models/video/transcript_usage.sql
+++ b/aspects/models/video/transcript_usage.sql
@@ -1,0 +1,11 @@
+select
+    emission_time,
+    org,
+    course_id,
+    splitByString('/xblock/', object_id)[2] as video_id,
+    actor_id
+from
+    {{ source('xapi', 'xapi_events_all_parsed') }}
+where
+    verb_id = 'http://adlnet.gov/expapi/verbs/interacted'
+    and JSON_VALUE(event_str, '$.result.extensions."https://w3id.org/xapi/video/extensions/cc-enabled"') = 'true'

--- a/aspects/models/video/video_plays.sql
+++ b/aspects/models/video/video_plays.sql
@@ -1,0 +1,13 @@
+-- model to support number of watches per video
+-- ref: https://edx.readthedocs.io/projects/edx-insights/en/latest/Reference.html#engagement-computations
+
+select
+    emission_time,
+    org,
+    course_id,
+    splitByString('/xblock/', object_id)[2] as video_id,
+    actor_id
+from
+    {{ source('xapi', 'video_playback_events') }}
+where
+    verb_id = 'https://w3id.org/xapi/video/verbs/played'


### PR DESCRIPTION
Adds two new models for issue https://github.com/openedx/oars-dbt/issues/3 :

- `video_plays`: contains a record for each time a learner played a video. Can be used to generate reports of total plays and unique watchers
- `transcript_usage`: contains a record for each time a transcript or closed caption was enabled. Can be used to generate reports for total transcription/caption usage as well as the number of unique learners who enabled transcription/closed captioning

For each model, org, course_id, and video_id are available as dimensions.

Question for reviewers: is there a more robust way of deriving a video ID from the object ID? This approach works for test data but uses a relatively naive approach and may not accurately capture the video ID from different environments.