### PR TITLE
feat: adds models for problem interaction reports (FC-0024)

### DIFF
--- a/aspects/macros/get_problem_id.sql
+++ b/aspects/macros/get_problem_id.sql
@@ -1,0 +1,7 @@
+
+-- extract the problem ID from the object ID
+-- either the problem id is at the end of the object ID
+-- or is followed by '/answer' or '/hint'
+{% macro get_problem_id(object_id) %}
+   regexpExtract(object_id, 'xblock/([\w\d-@\+:]*)', 1)
+{% endmacro %}

--- a/aspects/models/problems/int_problem_hints.sql
+++ b/aspects/models/problems/int_problem_hints.sql
@@ -1,0 +1,17 @@
+-- verb id for showanswer and hint events: http://adlnet.gov/expapi/verbs/asked
+
+select
+    emission_time,
+    org,
+    course_id,
+    {{ get_problem_id('object_id') }} as problem_id,
+    actor_id,
+    case
+        when object_id like '%/hint%' then 'hint'
+        when object_id like '%/answer%' then 'answer'
+        else 'N/A'
+    end as help_type
+from
+    {{ source('xapi', 'problem_events') }}
+where
+    verb_id = 'http://adlnet.gov/expapi/verbs/asked'

--- a/aspects/models/problems/int_problem_hints.sql
+++ b/aspects/models/problems/int_problem_hints.sql
@@ -1,5 +1,3 @@
--- verb id for showanswer and hint events: http://adlnet.gov/expapi/verbs/asked
-
 select
     emission_time,
     org,

--- a/aspects/models/problems/int_problem_results.sql
+++ b/aspects/models/problems/int_problem_results.sql
@@ -1,0 +1,81 @@
+-- select one record per (learner, problem, course, org) tuple
+-- contains either the first successful attempt
+-- or the most recent unsuccessful attempt
+
+
+-- find the timestamp of the earliest successful response
+-- this will be used to pick the xAPI event corresponding to that
+-- submission
+with successful_responses as (
+    select
+        org,
+        course_id,
+        problem_id,
+        actor_id,
+        min(emission_time) as first_success_at
+    from
+        {{ ref('problem_responses') }}
+    where
+        success
+    group by
+        org,
+        course_id,
+        problem_id,
+        actor_id
+),
+-- for all learners who did not submit a successful response,
+-- find the timestamp of the most recent unsuccessful response
+unsuccessful_responses as (
+    select
+        org,
+        course_id,
+        problem_id,
+        actor_id,
+        max(emission_time) as last_response_at
+    from
+        {{ ref('problem_responses') }}
+    where
+        actor_id not in (select distinct actor_id from successful_responses)
+    group by
+        org,
+        course_id,
+        problem_id,
+        actor_id
+),
+-- this CTE should have either:
+-- the first timestamp of a successful reponse, or
+-- if no successful responses for this learner, the timestamp of the last
+-- attempt
+responses as (
+    select
+        org,
+        course_id,
+        problem_id,
+        actor_id,
+        first_success_at as emission_time
+    from
+        successful_responses
+    union all
+    select
+        org,
+        course_id,
+        problem_id,
+        actor_id,
+        last_response_at as emission_time
+    from
+        unsuccessful_responses
+)
+
+select
+    emission_time,
+    org,
+    course_id,
+    problem_id,
+    actor_id,
+    responses,
+    success,
+    attempts
+from
+    {{ ref('problem_responses') }} problem_responses
+    join responses
+        using (org, course_id, problem_id, actor_id, emission_time)

--- a/aspects/models/problems/int_problem_results.sql
+++ b/aspects/models/problems/int_problem_results.sql
@@ -4,8 +4,7 @@
 
 
 -- find the timestamp of the earliest successful response
--- this will be used to pick the xAPI event corresponding to that
--- submission
+-- this will be used to pick the xAPI event corresponding to that submission
 with successful_responses as (
     select
         org,
@@ -42,10 +41,7 @@ unsuccessful_responses as (
         problem_id,
         actor_id
 ),
--- this CTE should have either:
--- the first timestamp of a successful reponse, or
--- if no successful responses for this learner, the timestamp of the last
--- attempt
+-- combine result sets for successful and unsuccessful problem submissions
 responses as (
     select
         org,

--- a/aspects/models/problems/learner_problem_summary.sql
+++ b/aspects/models/problems/learner_problem_summary.sql
@@ -1,0 +1,52 @@
+-- summary table for a learner's performance on and interactions with a
+-- particular problem
+with summary as (
+    select
+        org,
+        course_id,
+        problem_id,
+        actor_id,
+        success,
+        attempts,
+        0 as num_hints_displayed,
+        0 as num_answers_displayed
+    from {{ ref('int_problem_results') }}
+    union all
+    select
+        org,
+        course_id,
+        problem_id,
+        actor_id,
+        null as success,
+        null as attempts,
+        case help_type
+            when 'hint' then 1
+            else 0
+        end as num_hints_displayed,
+        case help_type
+            when 'answer' then 1
+            else 0
+        end as num_answers_displayed
+    from {{ ref('int_problem_hints') }}
+)
+
+-- n.b.: there should only be one row per org, course, problem, and actor
+-- in problem_results, so any(success) and any(attempts) should return the
+-- values from that part of the union and not the null values used as
+-- placeholders in the problem_hints part of the union
+select
+    org,
+    course_id,
+    problem_id,
+    actor_id,
+    coalesce(any(success), false) as success,
+    coalesce(any(attempts), 0) as attempts,
+    sum(num_hints_displayed) as num_hints_displayed,
+    sum(num_answers_displayed) as num_answers_displayed
+from
+    summary
+group by
+    org,
+    course_id,
+    problem_id,
+    actor_id

--- a/aspects/models/problems/problem_responses.sql
+++ b/aspects/models/problems/problem_responses.sql
@@ -1,0 +1,15 @@
+-- this model could support the answer distribution and problem
+-- submission count metrics
+select
+    emission_time,
+    org,
+    course_id,
+    {{ get_problem_id('object_id') }} as problem_id,
+    actor_id,
+    responses,
+    success,
+    attempts
+from
+    {{ source('xapi', 'problem_events') }}
+where
+    verb_id = 'https://w3id.org/xapi/acrossx/verbs/evaluated'

--- a/aspects/models/problems/problem_responses.sql
+++ b/aspects/models/problems/problem_responses.sql
@@ -1,5 +1,3 @@
--- this model could support the answer distribution and problem
--- submission count metrics
 select
     emission_time,
     org,

--- a/aspects/models/problems/schema.yml
+++ b/aspects/models/problems/schema.yml
@@ -1,0 +1,37 @@
+version: 2
+
+models:
+  - name: learner_problem_summary
+    description: "One record per learner per problem in a course"
+    columns:
+      - name: org
+      - name: course_id
+      - name: problem_id
+      - name: actor_id
+      - name: success
+        description: "The result of the last submission"
+        tests:
+          - not_null
+      - name: attempts
+        description: "The number of attempts made"
+        tests:
+          - not_null
+      - name: num_hints_displayed
+        description: "The number of times a learner asked for a hint"
+      - name: num_answers_displayed
+        description: "The number of times a learner requested the answers for the problem"
+
+  - name: problem_responses
+    description: "One record for each submitted response to a problem"
+    columns:
+      - name: emission_time
+      - name: org
+      - name: course_id
+      - name: problem_id
+      - name: actor_id
+      - name: responses
+        description: "The responses for this submission. If a problem has multiple parts, values for all parts will be in this field"
+      - name: success
+        description: "Boolean indicating whether the responses were correct"
+      - name: attempts
+        description: "Number indicating which attempt this was"

--- a/aspects/models/problems/schema.yml
+++ b/aspects/models/problems/schema.yml
@@ -35,3 +35,17 @@ models:
         description: "Boolean indicating whether the responses were correct"
       - name: attempts
         description: "Number indicating which attempt this was"
+
+  - name: int_problem_hints
+    description: "intermediate dataset for hints and answers displayed to learners"
+    columns:
+      - name: emission_time
+      - name: org
+      - name: course_id
+      - name: problem_id
+      - name: actor_id
+      - name: help_type
+        description: "whether the help displayed was a hint or an answer"
+        tests:
+          - accepted_values:
+              values: ["hint", "answer"]

--- a/aspects/tests/learner_problem_summary_uniqueness.sql
+++ b/aspects/tests/learner_problem_summary_uniqueness.sql
@@ -1,0 +1,14 @@
+select
+    org,
+    course_id,
+    problem_id,
+    actor_id,
+    count(*) as num_rows
+from
+    {{ ref('learner_problem_summary') }}
+group by
+    org,
+    course_id,
+    problem_id,
+    actor_id
+having num_rows > 1

--- a/aspects/tests/problem_results_uniqueness.sql
+++ b/aspects/tests/problem_results_uniqueness.sql
@@ -1,0 +1,18 @@
+-- problem_results should only have one record for the following
+-- combination of values:
+-- actor_id, problem_id, course_id, org
+
+select
+    org,
+    course_id,
+    problem_id,
+    actor_id,
+    count(*) as num_rows
+from
+    {{ ref('int_problem_results') }}
+group by
+    org,
+    course_id,
+    problem_id,
+    actor_id
+having num_rows > 1


### PR DESCRIPTION
Models should support the following reports listed in #4 :
- problem difficulty (via `learner_problem_summary`)
- answer distributions per problem (via `problem_responses`)
- problem submission counts (also via `problem_responses`)

These models have been tested with the `force_primary_key=1` setting to ensure they make proper use of indexes.