### PR TITLE
fix: adds enrollment_status to enrollments_by_day (FC-0024)

### DIFF
--- a/aspects/models/enrollment/enrollments_by_day.sql
+++ b/aspects/models/enrollment/enrollments_by_day.sql
@@ -17,10 +17,14 @@ select
       )
     )
   )) as enrollment_status_date,
-  actor_id,
-  object_id,
-  course_id,
   org,
-  enrollment_mode
+  course_id,
+  actor_id,
+  enrollment_mode,
+  if(
+    verb_id = 'http://adlnet.gov/expapi/verbs/registered',
+    'registered',
+    'unregistered'
+  ) as enrollment_status
 from
-  {{ ref('stg_enrollment_windows') }}
+  {{ ref('int_enrollment_windows') }}

--- a/aspects/models/enrollment/int_enrollment_windows.sql
+++ b/aspects/models/enrollment/int_enrollment_windows.sql
@@ -1,10 +1,10 @@
 with enrollments_ranked as (
   select
-    actor_id,
-    object_id,
-    course_id,
     org,
+    course_id,
+    actor_id,
     enrollment_mode,
+    verb_id,
     emission_time as window_start_at,
     anyOrNull(emission_time)
       over (partition by org, course_id, actor_id order by emission_time asc rows between 1 following and 1 following)
@@ -15,10 +15,10 @@ with enrollments_ranked as (
 )
 
 select
-  actor_id,
-  object_id,
-  course_id,
   org,
+  course_id,
+  actor_id,
+  verb_id,
   enrollment_mode,
   date_trunc('day', window_start_at) as window_start_date,
   date_trunc('day', coalesce(window_end_at, now())) as window_end_date,


### PR DESCRIPTION
This PR fixes a broken "acceptable values" test for `enrollments_by_day`. It also renames `stg_enrollment_windows` to `int_enrollment_windows` to be more in-line with common dbt practice.