### PR TITLE
refactor: use course_key instead of course_id (FC-0024)

### DIFF
--- a/aspects/models/base/sources.yml
+++ b/aspects/models/base/sources.yml
@@ -27,7 +27,7 @@ sources:
           - name: emission_time
           - name: actor_id
           - name: object_id
-          - name: course_id
+          - name: course_key
           - name: org
           - name: verb_id
           - name: enrollment_mode
@@ -39,7 +39,7 @@ sources:
           - name: emission_time
           - name: actor_id
           - name: object_id
-          - name: course_id
+          - name: course_key
           - name: org
           - name: verb_id
           - name: video_position
@@ -51,7 +51,7 @@ sources:
           - name: emission_time
           - name: actor_id
           - name: object_id
-          - name: course_id
+          - name: course_key
           - name: org
           - name: verb_id
           - name: responses
@@ -67,7 +67,7 @@ sources:
           - name: emission_time
           - name: actor_id
           - name: object_id
-          - name: course_id
+          - name: course_key
           - name: org
           - name: verb_id
           - name: object_type

--- a/aspects/models/enrollment/enrollments_by_day.sql
+++ b/aspects/models/enrollment/enrollments_by_day.sql
@@ -18,7 +18,7 @@ select
     )
   )) as enrollment_status_date,
   org,
-  course_id,
+  course_key,
   actor_id,
   enrollment_mode,
   if(

--- a/aspects/models/enrollment/int_enrollment_windows.sql
+++ b/aspects/models/enrollment/int_enrollment_windows.sql
@@ -1,22 +1,22 @@
 with enrollments_ranked as (
   select
     org,
-    course_id,
+    course_key,
     actor_id,
     enrollment_mode,
     verb_id,
     emission_time as window_start_at,
     anyOrNull(emission_time)
-      over (partition by org, course_id, actor_id order by emission_time asc rows between 1 following and 1 following)
+      over (partition by org, course_key, actor_id order by emission_time asc rows between 1 following and 1 following)
       as window_end_at,
-    rank() over (partition by date(emission_time), org, course_id, actor_id order by emission_time desc) as rank
+    rank() over (partition by date(emission_time), org, course_key, actor_id order by emission_time desc) as rank
   from
     {{ source('xapi', 'enrollment_events') }}
 )
 
 select
   org,
-  course_id,
+  course_key,
   actor_id,
   verb_id,
   enrollment_mode,

--- a/aspects/models/problems/int_problem_hints.sql
+++ b/aspects/models/problems/int_problem_hints.sql
@@ -1,7 +1,7 @@
 select
     emission_time,
     org,
-    course_id,
+    course_key,
     {{ get_problem_id('object_id') }} as problem_id,
     actor_id,
     case

--- a/aspects/models/problems/int_problem_results.sql
+++ b/aspects/models/problems/int_problem_results.sql
@@ -8,7 +8,7 @@
 with successful_responses as (
     select
         org,
-        course_id,
+        course_key,
         problem_id,
         actor_id,
         min(emission_time) as first_success_at
@@ -18,7 +18,7 @@ with successful_responses as (
         success
     group by
         org,
-        course_id,
+        course_key,
         problem_id,
         actor_id
 ),
@@ -27,7 +27,7 @@ with successful_responses as (
 unsuccessful_responses as (
     select
         org,
-        course_id,
+        course_key,
         problem_id,
         actor_id,
         max(emission_time) as last_response_at
@@ -37,7 +37,7 @@ unsuccessful_responses as (
         actor_id not in (select distinct actor_id from successful_responses)
     group by
         org,
-        course_id,
+        course_key,
         problem_id,
         actor_id
 ),
@@ -45,7 +45,7 @@ unsuccessful_responses as (
 responses as (
     select
         org,
-        course_id,
+        course_key,
         problem_id,
         actor_id,
         first_success_at as emission_time
@@ -54,7 +54,7 @@ responses as (
     union all
     select
         org,
-        course_id,
+        course_key,
         problem_id,
         actor_id,
         last_response_at as emission_time
@@ -65,7 +65,7 @@ responses as (
 select
     emission_time,
     org,
-    course_id,
+    course_key,
     problem_id,
     actor_id,
     responses,
@@ -74,4 +74,4 @@ select
 from
     {{ ref('problem_responses') }} problem_responses
     join responses
-        using (org, course_id, problem_id, actor_id, emission_time)
+        using (org, course_key, problem_id, actor_id, emission_time)

--- a/aspects/models/problems/learner_problem_summary.sql
+++ b/aspects/models/problems/learner_problem_summary.sql
@@ -3,7 +3,7 @@
 with summary as (
     select
         org,
-        course_id,
+        course_key,
         problem_id,
         actor_id,
         success,
@@ -14,7 +14,7 @@ with summary as (
     union all
     select
         org,
-        course_id,
+        course_key,
         problem_id,
         actor_id,
         null as success,
@@ -36,7 +36,7 @@ with summary as (
 -- placeholders in the problem_hints part of the union
 select
     org,
-    course_id,
+    course_key,
     problem_id,
     actor_id,
     coalesce(any(success), false) as success,
@@ -47,6 +47,6 @@ from
     summary
 group by
     org,
-    course_id,
+    course_key,
     problem_id,
     actor_id

--- a/aspects/models/problems/problem_responses.sql
+++ b/aspects/models/problems/problem_responses.sql
@@ -1,7 +1,7 @@
 select
     emission_time,
     org,
-    course_id,
+    course_key,
     {{ get_problem_id('object_id') }} as problem_id,
     actor_id,
     responses,

--- a/aspects/models/problems/schema.yml
+++ b/aspects/models/problems/schema.yml
@@ -5,7 +5,7 @@ models:
     description: "One record per learner per problem in a course"
     columns:
       - name: org
-      - name: course_id
+      - name: course_key
       - name: problem_id
       - name: actor_id
       - name: success
@@ -26,7 +26,7 @@ models:
     columns:
       - name: emission_time
       - name: org
-      - name: course_id
+      - name: course_key
       - name: problem_id
       - name: actor_id
       - name: responses
@@ -41,7 +41,7 @@ models:
     columns:
       - name: emission_time
       - name: org
-      - name: course_id
+      - name: course_key
       - name: problem_id
       - name: actor_id
       - name: help_type

--- a/aspects/models/video/schema.yml
+++ b/aspects/models/video/schema.yml
@@ -6,7 +6,7 @@ models:
     columns:
       - name: emission_time
       - name: org
-      - name: course_id
+      - name: course_key
       - name: video_id
       - name: actor_id
 
@@ -15,6 +15,6 @@ models:
     columns:
       - name: emission_time
       - name: org
-      - name: course_id
+      - name: course_key
       - name: video_id
       - name: actor_id

--- a/aspects/models/video/transcript_usage.sql
+++ b/aspects/models/video/transcript_usage.sql
@@ -1,7 +1,7 @@
 select
     emission_time,
     org,
-    course_id,
+    splitByString('/', course_id)[-1] as course_key,
     splitByString('/xblock/', object_id)[2] as video_id,
     actor_id
 from

--- a/aspects/models/video/video_plays.sql
+++ b/aspects/models/video/video_plays.sql
@@ -4,7 +4,7 @@
 select
     emission_time,
     org,
-    course_id,
+    course_key,
     splitByString('/xblock/', object_id)[2] as video_id,
     actor_id
 from


### PR DESCRIPTION
Following from https://github.com/openedx/tutor-contrib-aspects/pull/193, we'll need to use `course_key` instead of `course_id` in the top-level materialized views.