### PR TITLE
fix: use course_key in tests (FC-0024)

### DIFF
--- a/aspects/tests/learner_problem_summary_uniqueness.sql
+++ b/aspects/tests/learner_problem_summary_uniqueness.sql
@@ -1,6 +1,6 @@
 select
     org,
-    course_id,
+    course_key,
     problem_id,
     actor_id,
     count(*) as num_rows
@@ -8,7 +8,7 @@ from
     {{ ref('learner_problem_summary') }}
 group by
     org,
-    course_id,
+    course_key,
     problem_id,
     actor_id
 having num_rows > 1

--- a/aspects/tests/problem_results_uniqueness.sql
+++ b/aspects/tests/problem_results_uniqueness.sql
@@ -4,7 +4,7 @@
 
 select
     org,
-    course_id,
+    course_key,
     problem_id,
     actor_id,
     count(*) as num_rows
@@ -12,7 +12,7 @@ from
     {{ ref('int_problem_results') }}
 group by
     org,
-    course_id,
+    course_key,
     problem_id,
     actor_id
 having num_rows > 1


### PR DESCRIPTION
The tests currently fail because I forgot to update them to use `course_key` instead of `course_id` when we made that switch. My apologies for the oversight.