### PR TITLE
Update Security E-mail Address

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -93,4 +93,4 @@ file in this repo.
 Reporting Security Issues
 *************************
 
-Please do not report security issues in public. Please email security@axim.org.
+Please do not report security issues in public. Please email security@openedx.org.


### PR DESCRIPTION
Use the openedx security e-mail address instead of the Axim One.

See https://github.com/openedx/wg-security/issues/15 for details.