### PR TITLE
fix: correctly pass through entity names (FC-0024)

### DIFF
--- a/aspects/models/problems/fact_learner_problem_summary.sql
+++ b/aspects/models/problems/fact_learner_problem_summary.sql
@@ -4,7 +4,10 @@ with results_with_hints as (
     select
         org,
         course_key,
+        course_name,
+        run_name,
         problem_id,
+        problem_name,
         actor_id,
         success,
         attempts,
@@ -15,7 +18,10 @@ with results_with_hints as (
     select
         org,
         course_key,
+        course_name,
+        run_name,
         problem_id,
+        problem_name,
         actor_id,
         null as success,
         null as attempts,
@@ -28,42 +34,31 @@ with results_with_hints as (
             else 0
         end as num_answers_displayed
     from {{ ref('int_problem_hints') }}
-), summary as (
-    -- n.b.: there should only be one row per org, course, problem, and actor
-    -- in problem_results, so any(success) and any(attempts) should return the
-    -- values from that part of the union and not the null values used as
-    -- placeholders in the problem_hints part of the union
-    select
-        org,
-        course_key,
-        problem_id,
-        actor_id,
-        coalesce(any(success), false) as success,
-        coalesce(any(attempts), 0) as attempts,
-        sum(num_hints_displayed) as num_hints_displayed,
-        sum(num_answers_displayed) as num_answers_displayed
-    from
-        results_with_hints
-    group by
-        org,
-        course_key,
-        problem_id,
-        actor_id
 )
 
+-- n.b.: there should only be one row per org, course, problem, and actor
+-- in problem_results, so any(success) and any(attempts) should return the
+-- values from that part of the union and not the null values used as
+-- placeholders in the problem_hints part of the union
 select
-    summary.org as org,
-    courses.course_name as course_name,
-    splitByString('+', courses.course_key)[-1] as run_name,
-    blocks.block_name as problem_name,
-    summary.actor_id as actor_id,
-    summary.success as success,
-    summary.attempts as attempts,
-    summary.num_hints_displayed as num_hints_displayed,
-    summary.num_answers_displayed as num_answers_displayed
+    org,
+    course_key,
+    course_name,
+    run_name,
+    problem_id,
+    problem_name,
+    actor_id,
+    coalesce(any(success), false) as success,
+    coalesce(any(attempts), 0) as attempts,
+    sum(num_hints_displayed) as num_hints_displayed,
+    sum(num_answers_displayed) as num_answers_displayed
 from
-    summary
-    join {{ source('event_sink', 'course_names')}} courses
-         on summary.course_key = courses.course_key
-    join {{ source('event_sink', 'course_block_names')}} blocks
-         on summary.problem_id = blocks.location
+    results_with_hints
+group by
+    org,
+    course_key,
+    course_name,
+    run_name,
+    problem_id,
+    problem_name,
+    actor_id

--- a/aspects/models/problems/fact_problem_responses.sql
+++ b/aspects/models/problems/fact_problem_responses.sql
@@ -17,8 +17,10 @@ with responses as (
 select
     responses.emission_time as emission_time,
     responses.org as org,
+    courses.course_key as course_key,
     courses.course_name as course_name,
     splitByString('+', courses.course_key)[-1] as run_name,
+    responses.problem_id as problem_id,
     blocks.block_name as problem_name,
     responses.actor_id as actor_id,
     responses.responses as responses,

--- a/aspects/models/problems/int_problem_hints.sql
+++ b/aspects/models/problems/int_problem_hints.sql
@@ -1,15 +1,34 @@
+with hints as (
+    select
+        emission_time,
+        org,
+        course_key,
+        {{ get_problem_id('object_id') }} as problem_id,
+        actor_id,
+        case
+            when object_id like '%/hint%' then 'hint'
+            when object_id like '%/answer%' then 'answer'
+            else 'N/A'
+        end as help_type
+    from
+        {{ source('xapi', 'problem_events') }}
+    where
+        verb_id = 'http://adlnet.gov/expapi/verbs/asked'
+)
+
 select
-    emission_time,
-    org,
-    course_key,
-    {{ get_problem_id('object_id') }} as problem_id,
-    actor_id,
-    case
-        when object_id like '%/hint%' then 'hint'
-        when object_id like '%/answer%' then 'answer'
-        else 'N/A'
-    end as help_type
+    hints.emission_time as emission_time,
+    hints.org as org,
+    hints.course_key as course_key,
+    courses.course_name as course_name,
+    splitByString('+', courses.course_key)[-1] as run_name,
+    hints.problem_id as problem_id,
+    blocks.block_name as problem_name,
+    hints.actor_id as actor_id,
+    hints.help_type as help_type
 from
-    {{ source('xapi', 'problem_events') }}
-where
-    verb_id = 'http://adlnet.gov/expapi/verbs/asked'
+    hints
+    join {{ source('event_sink', 'course_names')}} courses
+         on hints.course_key = courses.course_key
+    join {{ source('event_sink', 'course_block_names')}} blocks
+         on hints.problem_id = blocks.location

--- a/aspects/models/problems/int_problem_results.sql
+++ b/aspects/models/problems/int_problem_results.sql
@@ -13,9 +13,10 @@ with successful_responses as (
         actor_id,
         min(emission_time) as first_success_at
     from
-        {{ ref('problem_responses') }}
+        {{ ref('fact_problem_responses') }}
     where
-        success
+        -- clickhouse throws an error when shortening this to `where success`
+        success = true
     group by
         org,
         course_key,
@@ -32,7 +33,7 @@ unsuccessful_responses as (
         actor_id,
         max(emission_time) as last_response_at
     from
-        {{ ref('problem_responses') }}
+        {{ ref('fact_problem_responses') }}
     where
         actor_id not in (select distinct actor_id from successful_responses)
     group by
@@ -66,12 +67,15 @@ select
     emission_time,
     org,
     course_key,
+    course_name,
+    run_name,
     problem_id,
+    problem_name,
     actor_id,
     responses,
     success,
     attempts
 from
-    {{ ref('problem_responses') }} problem_responses
+    {{ ref('fact_problem_responses') }} problem_responses
     join responses
         using (org, course_key, problem_id, actor_id, emission_time)


### PR DESCRIPTION
Fixes issues with the problem interaction models where fields weren't being passed through correctly, leading to errors at query time.

This PR also updates the strategy for joining entity names, avoiding an unnecessary join in the `fact_learner_problem_summary` model. `dbt test` now succeeds and these models correctly display data in the instructor dashboard. This should unblock the [corresponding PR in tutor-contrib-aspects](https://github.com/openedx/tutor-contrib-aspects/pull/272).