### PR TITLE
feat: include course_key in final output models (FC-0033)

### DIFF
--- a/aspects/models/enrollment/fact_enrollments.sql
+++ b/aspects/models/enrollment/fact_enrollments.sql
@@ -13,6 +13,7 @@ with enrollments as (
 select
     enrollments.emission_time as emission_time,
     enrollments.org as org,
+    enrollments.course_key as course_key,
     courses.course_name as course_name,
     courses.course_run as course_run,
     enrollments.actor_id as actor_id,

--- a/aspects/models/problems/schema.yml
+++ b/aspects/models/problems/schema.yml
@@ -5,8 +5,10 @@ models:
     description: "One record per learner per problem in a course"
     columns:
       - name: org
+      - name: course_key
       - name: course_name
       - name: course_run
+      - name: problem_id
       - name: problem_name
       - name: actor_id
       - name: success
@@ -27,8 +29,10 @@ models:
     columns:
       - name: emission_time
       - name: org
+      - name: course_key
       - name: course_name
       - name: course_run
+      - name: problem_id
       - name: problem_name
       - name: actor_id
       - name: responses

--- a/aspects/models/video/fact_transcript_usage.sql
+++ b/aspects/models/video/fact_transcript_usage.sql
@@ -15,8 +15,10 @@ with transcripts as (
 select
     transcripts.emission_time as emission_time,
     transcripts.org as org,
+    transcripts.course_key as course_key,
     courses.course_name as course_name,
     courses.course_run as course_run,
+    transcripts.video_id as video_id,
     blocks.block_name as video_name,
     transcripts.actor_id as actor_id
 from

--- a/aspects/models/video/fact_video_plays.sql
+++ b/aspects/models/video/fact_video_plays.sql
@@ -16,8 +16,10 @@ with plays as (
 select
     plays.emission_time as emission_time,
     plays.org as org,
+    plays.course_key as course_key,
     courses.course_name as course_name,
     courses.course_run as course_run,
+    plays.video_id as video_id,
     blocks.block_name as video_name,
     plays.actor_id as actor_id
 from

--- a/aspects/models/video/schema.yml
+++ b/aspects/models/video/schema.yml
@@ -6,8 +6,10 @@ models:
     columns:
       - name: emission_time
       - name: org
+      - name: course_key
       - name: course_name
       - name: course_run
+      - name: video_id
       - name: video_name
       - name: actor_id
 
@@ -16,7 +18,9 @@ models:
     columns:
       - name: emission_time
       - name: org
+      - name: course_key
       - name: course_name
       - name: course_run
+      - name: video_id
       - name: video_name
       - name: actor_id


### PR DESCRIPTION
Including `course_key` in the models used by Superset will allow us to make better use of our primary keys, thereby improving query performance and stability. The problem interaction models already had `course_key` and `problem_id` in the models so all that was needed was to bring the documentation in line with the implementation.