### PR TITLE
feat: create `dim_course_blocks` for entity lookup (FC-0033)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -24,7 +24,7 @@ Installation
 ************
 
 1. ``pip install -r requirements.txt`` will install dbt and other required packages.
-2. ``dbt deps`` will install the dbt packages defined in `aspects/packages.yml <aspects/packages.yml>`_ (this step needs to be run when initializing your project or when changing the package list).
+2. ``dbt deps`` will install the dbt packages defined in `packages.yml <packages.yml>`_ (this step needs to be run when initializing your project or when changing the package list).
 
 Running dbt
 ***********

--- a/models/base/dim_course_blocks.sql
+++ b/models/base/dim_course_blocks.sql
@@ -1,0 +1,12 @@
+select
+    courses.org as org,
+    courses.course_key as course_key,
+    courses.course_name as course_name,
+    courses.course_run as course_run,
+    blocks.location as block_id,
+    blocks.block_name as block_name
+from
+    {{ source('event_sink', 'course_block_names') }} blocks
+    join {{ source('event_sink', 'course_names')}} courses
+        on blocks.course_key = courses.course_key
+settings join_algorithm='direct'

--- a/models/base/sources.yml
+++ b/models/base/sources.yml
@@ -81,6 +81,7 @@ sources:
         columns:
           - name: location
           - name: block_name
+          - name: course_key
 
       - name: course_names
         columns:

--- a/models/problems/fact_problem_responses.sql
+++ b/models/problems/fact_problem_responses.sql
@@ -18,8 +18,8 @@ select
     responses.emission_time as emission_time,
     responses.org as org,
     responses.course_key as course_key,
-    courses.course_name as course_name,
-    courses.course_run as course_run,
+    blocks.course_name as course_name,
+    blocks.course_run as course_run,
     responses.problem_id as problem_id,
     blocks.block_name as problem_name,
     responses.actor_id as actor_id,
@@ -28,7 +28,6 @@ select
     responses.attempts as attempts
 from
     responses
-    join {{ source('event_sink', 'course_names')}} courses
-         on responses.course_key = courses.course_key
-    join {{ source('event_sink', 'course_block_names')}} blocks
-         on responses.problem_id = blocks.location
+    join {{ ref('dim_course_blocks')}} blocks
+         on (responses.course_key = blocks.course_key
+             and responses.problem_id = blocks.block_id)

--- a/models/problems/int_problem_hints.sql
+++ b/models/problems/int_problem_hints.sql
@@ -20,15 +20,14 @@ select
     hints.emission_time as emission_time,
     hints.org as org,
     hints.course_key as course_key,
-    courses.course_name as course_name,
-    courses.course_run as course_run,
+    blocks.course_name as course_name,
+    blocks.course_run as course_run,
     hints.problem_id as problem_id,
     blocks.block_name as problem_name,
     hints.actor_id as actor_id,
     hints.help_type as help_type
 from
     hints
-    join {{ source('event_sink', 'course_names')}} courses
-         on hints.course_key = courses.course_key
-    join {{ source('event_sink', 'course_block_names')}} blocks
-         on hints.problem_id = blocks.location
+    join {{ ref('dim_course_blocks')}} blocks
+         on (hints.course_key = blocks.course_key
+             and hints.problem_id = blocks.block_id)

--- a/models/video/fact_transcript_usage.sql
+++ b/models/video/fact_transcript_usage.sql
@@ -16,14 +16,13 @@ select
     transcripts.emission_time as emission_time,
     transcripts.org as org,
     transcripts.course_key as course_key,
-    courses.course_name as course_name,
-    courses.course_run as course_run,
+    blocks.course_name as course_name,
+    blocks.course_run as course_run,
     transcripts.video_id as video_id,
     blocks.block_name as video_name,
     transcripts.actor_id as actor_id
 from
     transcripts
-    join {{ source('event_sink', 'course_names')}} courses
-         on transcripts.course_key = courses.course_key
-    join {{ source('event_sink', 'course_block_names')}} blocks
-         on transcripts.video_id = blocks.location
+    join {{ ref('dim_course_blocks')}} blocks
+         on (transcripts.course_key = blocks.course_key
+             and transcripts.video_id = blocks.block_id)

--- a/models/video/fact_video_plays.sql
+++ b/models/video/fact_video_plays.sql
@@ -17,14 +17,13 @@ select
     plays.emission_time as emission_time,
     plays.org as org,
     plays.course_key as course_key,
-    courses.course_name as course_name,
-    courses.course_run as course_run,
+    blocks.course_name as course_name,
+    blocks.course_run as course_run,
     plays.video_id as video_id,
     blocks.block_name as video_name,
     plays.actor_id as actor_id
 from
     plays
-    join {{ source('event_sink', 'course_names')}} courses
-         on plays.course_key = courses.course_key
-    join {{ source('event_sink', 'course_block_names')}} blocks
-         on plays.video_id = blocks.location
+    join {{ ref('dim_course_blocks')}} blocks
+         on (plays.course_key = blocks.course_key
+             and plays.video_id = blocks.block_id)


### PR DESCRIPTION
This creates a view, `dim_course_blocks`, that leverages ClickHouse's "direct" join type to improve query performance when adding entity names to larger datasets.

This view could also be used for the `dim_course_videos` and `dim_course_problems` datasets that Superset uses for dashboard filters.

**Please note:** to get this working with Superset, I needed to grant `dictGet` permissions to the `event_sink` database for the Aspects reporting user. I can add that in a subsequent PR to use a version of this project that includes this change in the aspects tutor plugin.