### PR TITLE
feat: add base model for grading events (FC-0033)

### DIFF
--- a/models/base/sources.yml
+++ b/models/base/sources.yml
@@ -33,7 +33,7 @@ sources:
           - name: enrollment_mode
 
       - name: video_playback_events
-        identifier: "{{ env_var('OARS_VIDEO_PLAYBACK_EVENTS_TABLE', 'video_playback_events') }}"
+        identifier: "{{ env_var('ASPECTS_VIDEO_PLAYBACK_EVENTS_TABLE', 'video_playback_events') }}"
         columns:
           - name: event_id
           - name: emission_time
@@ -45,7 +45,7 @@ sources:
           - name: video_position
 
       - name: problem_events
-        identifier: "{{ env_var('OARS_PROBLEM_EVENTS_TABLE', 'problem_events') }}"
+        identifier: "{{ env_var('ASPECTS_PROBLEM_EVENTS_TABLE', 'problem_events') }}"
         columns:
           - name: event_id
           - name: emission_time
@@ -61,7 +61,7 @@ sources:
           - name: attempts
 
       - name: navigation_events
-        identifier: "{{ env_var('OARS_NAVIGATION_EVENTS_TABLE', 'navigation_events') }}"
+        identifier: "{{ env_var('ASPECTS_NAVIGATION_EVENTS_TABLE', 'navigation_events') }}"
         columns:
           - name: event_id
           - name: emission_time
@@ -73,6 +73,18 @@ sources:
           - name: object_type
           - name: starting_position
           - name: ending_point
+
+      - name: grading_events
+        identifier: "{{ env_var('ASPECTS_GRADING_EVENTS_TABLE', 'grading_events') }}"
+        columns:
+          - name: event_id
+          - name: emission_time
+          - name: actor_id
+          - name: object_id
+          - name: course_key
+          - name: org
+          - name: verb_id
+          - name: scaled_score
 
   - name: event_sink
     database: "{{ env_var('ASPECTS_EVENT_SINK_DATABASE', 'event_sink')}}"

--- a/models/grading/fact_grades.sql
+++ b/models/grading/fact_grades.sql
@@ -31,10 +31,16 @@ select
     grades.actor_id as actor_id,
     cast(grades.scaled_score as Float) as scaled_score,
     case
-        when scaled_score > 0.9 then '90-100%'
-        when scaled_score > 0.8 then '80-89%'
-        when scaled_score > 0.7 then '70-79%'
-        else '< 70%'
+        when scaled_score >= 0.9 then '90-100%'
+        when scaled_score >= 0.8 and scaled_score < 0.9 then '80-89%'
+        when scaled_score >= 0.7 and scaled_score < 0.8 then '70-79%'
+        when scaled_score >= 0.6 and scaled_score < 0.7 then '60-69%'
+        when scaled_score >= 0.5 and scaled_score < 0.6 then '50-59%'
+        when scaled_score >= 0.4 and scaled_score < 0.5 then '40-49%'
+        when scaled_score >= 0.3 and scaled_score < 0.4 then '30-39%'
+        when scaled_score >= 0.2 and scaled_score < 0.3 then '20-29%'
+        when scaled_score >= 0.1 and scaled_score < 0.2 then '10-19%'
+        else '0-9%'
     end as grade_bucket
 from
     grades

--- a/models/grading/fact_grades.sql
+++ b/models/grading/fact_grades.sql
@@ -1,0 +1,44 @@
+with grades as (
+    select
+        emission_time,
+        org,
+        course_key,
+        case
+            when object_id like '%/course/%' then 'course'
+            when object_id like '%@sequential+block@%' then 'subsection'
+            when object_id like '%@problem+block@%' then 'problem'
+        end as grade_type,
+        if(
+            grade_type = 'course',
+            splitByString('/course/', object_id)[-1],
+            splitByString('/xblock/', object_id)[-1]
+        ) as entity_id,
+        actor_id,
+        scaled_score
+    from
+        {{ source('xapi', 'grading_events') }}
+)
+
+select
+    grades.emission_time as emission_time,
+    grades.org as org,
+    grades.course_key as course_key,
+    courses.course_name as course_name,
+    courses.course_run as course_run,
+    grades.entity_id as entity_id,
+    if(blocks.block_name != '', blocks.block_name, courses.course_name) as entity_name,
+    grades.grade_type as grade_type,
+    grades.actor_id as actor_id,
+    cast(grades.scaled_score as Float) as scaled_score,
+    case
+        when scaled_score > 0.9 then '90-100%'
+        when scaled_score > 0.8 then '80-89%'
+        when scaled_score > 0.7 then '70-79%'
+        else '< 70%'
+    end as grade_bucket
+from
+    grades
+    join {{ source('event_sink', 'course_names')}} courses
+        on grades.course_key = courses.course_key
+    left join {{ source('event_sink', 'course_block_names') }} blocks
+        on grades.entity_id = blocks.location

--- a/models/grading/schema.yml
+++ b/models/grading/schema.yml
@@ -1,0 +1,25 @@
+version: 2
+
+models:
+  - name: fact_grades
+    description: "One record per grading event for courses, subsections, and problems"
+    columns:
+      - name: emission_time
+        description: "Timestamp, to the second, of when this event was emitted"
+      - name: org
+      - name: course_key
+      - name: course_name
+      - name: course_run
+      - name: entity_id
+        description: "The block ID or course key for the graded entity"
+      - name: entity_name
+      - name: grade_type
+        description: "The type of object graded"
+        tests:
+          - accepted_values:
+              values: ["course", "subsection", "problem"]
+      - name: actor_id
+      - name: scaled_score
+        description: "A ratio between 0 and 1, inclusive, of the learner's grade"
+      - name: grade_bucket
+        description: "A displayable value of grades sorted into 10% buckets. Useful for grouping grades together to show high-level learner performance"


### PR DESCRIPTION
This introduces `fact_grades`, which joins in entity names and transforms data to be used to analyze course, subsection, and problem performance. From this model we could create charts that display high-level information about how learners are performing on courses, subsections, and problems.