### PR TITLE
feat: add base model for forum interactions (FC-0033)

### DIFF
--- a/models/base/sources.yml
+++ b/models/base/sources.yml
@@ -86,6 +86,17 @@ sources:
           - name: verb_id
           - name: scaled_score
 
+      - name: forum_events
+        identifier: "{{ env_var('ASPECTS_FORUM_EVENTS_TABLE', 'forum_events') }}"
+        columns:
+          - name: event_id
+          - name: emission_time
+          - name: org
+          - name: course_key
+          - name: actor_id
+          - name: object_id
+          - name: verb_id
+
   - name: event_sink
     database: "{{ env_var('ASPECTS_EVENT_SINK_DATABASE', 'event_sink')}}"
     tables:

--- a/models/forum/fact_forum_interactions.sql
+++ b/models/forum/fact_forum_interactions.sql
@@ -1,0 +1,14 @@
+select
+    forum.event_id as event_id,
+    forum.emission_time as emission_time,
+    forum.org as org,
+    forum.course_key as course_key,
+    courses.course_name as course_name,
+    courses.course_run as course_run,
+    forum.object_id as object_id,
+    forum.actor_id as actor_id,
+    forum.verb_id as verb_id
+from
+    {{ source('xapi', 'forum_events') }} forum
+    join {{ source('event_sink', 'course_names') }} courses
+        on (forum.course_key = courses.course_key)


### PR DESCRIPTION
This adds `fact_forum_interactions`, which pulls course name and course run into the forum interaction dataset. This model can be used to answer questions like "how many learners were active on a course's forums" and "how much do individual learners interact with the forum".