### PR TITLE
feat: add dbt documentation

### DIFF
--- a/.github/profiles.yml
+++ b/.github/profiles.yml
@@ -1,0 +1,11 @@
+aspects: # this needs to match the profile in your dbt_project.yml file
+  target: dev
+  outputs:
+    dev:
+      type: clickhouse
+      schema: xapi
+      host: localhost
+      port: 8123
+      user: ch_admin
+      password: 'ch_password'
+      secure: False

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -1,0 +1,48 @@
+# Build documentation for dbt-aspects on every PR to main.
+# Deploy documentation to gh-pages branch on every push to main.
+
+name: Build documentation
+
+on:
+  push:
+    branches:
+      - main
+
+env:
+  DBT_PROFILES_DIR: ./.github/
+  CLICKHOUSE_DB: "xapi"
+  CLICKHOUSE_USER: "ch_admin"
+  CLICKHOUSE_PASSWORD: "ch_password"
+
+jobs:
+  build:
+    name: Deploy dbt docs to github pages
+    runs-on: ubuntu-latest
+    permissions:
+      contents: "read"
+      id-token: "write"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.SEMANTIC_RELEASE_GITHUB_TOKEN }}
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.8.x"
+      - name: Install dependencies
+        run: |
+          pip install -r requirements.txt
+          dbt deps
+      - name: Run Clickhouse
+        run: |
+          docker compose up -d
+      - name: Build docs
+        run: |
+          dbt docs generate
+      - name: Deploy
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.SEMANTIC_RELEASE_GITHUB_TOKEN }}
+          publish_dir: ./target
+          commit_message: "docs: update docs for "

--- a/clickhouse/config/docker_config.xml
+++ b/clickhouse/config/docker_config.xml
@@ -1,0 +1,23 @@
+<clickhouse>
+
+    <!-- Port for HTTP API. See also 'https_port' for secure connections.
+         This interface is also used by ODBC and JDBC drivers (DataGrip, Dbeaver, ...)
+         and by most of web interfaces (embedded UI, Grafana, Redash, ...).
+    -->
+    <http_port>8123</http_port>
+
+    <!-- Port for interaction by native protocol with:
+         - clickhouse-client and other native ClickHouse tools (clickhouse-benchmark,
+           clickhouse-copier);
+         - clickhouse-server with other clickhouse-servers for distributed query processing;
+         - ClickHouse drivers and applications supporting native protocol
+         (this protocol is also informally called as "the TCP protocol");
+         See also 'tcp_port_secure' for secure connections.
+    -->
+    <tcp_port>9000</tcp_port>
+
+    <listen_host>::</listen_host>
+    <listen_host>0.0.0.0</listen_host>
+    <listen_try>1</listen_try>
+
+</clickhouse>

--- a/clickhouse/users/default-user.xml
+++ b/clickhouse/users/default-user.xml
@@ -1,0 +1,18 @@
+<clickhouse>
+  <!-- Docs: <https://clickhouse.com/docs/en/operations/settings/settings_users/> -->
+  <users>
+    <!-- Remove default user -->
+    <default remove="remove">
+    </default>
+
+    <ch_admin>
+      <profile>default</profile>
+      <networks>
+        <ip>::/0</ip>
+      </networks>
+      <password>ch_password</password>
+      <quota>default</quota>
+      <access_management>1</access_management>
+    </ch_admin>
+  </users>
+</clickhouse>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,18 @@
+services:
+  clickhouse:
+    image: clickhouse/clickhouse-server:23.8
+    environment:
+      CLICKHOUSE_DB: "xapi"
+      CLICKHOUSE_USER: "ch_admin"
+      CLICKHOUSE_PASSWORD: "ch_password"
+      CLICKHOUSE_DEFAULT_ACCESS_MANAGEMENT: 1
+    ports:
+      - 8123:8123
+      - 9006:9000
+    ulimits:
+      nofile:
+        soft: 262144
+        hard: 262144
+    volumes:
+      - ./clickhouse/config:/etc/clickhouse-server/config.d/
+      - ./clickhouse/users:/etc/clickhouse-server/users.d/


### PR DESCRIPTION
### Description

This PR creates a GitHub workflow to generate the DBT docs and publish it to GitHub pages.

The destination branch is `gh-pages` and the documentation is generated on every push a main.