### PR TITLE
feat: support multi-part problem responses (FC-0033)

### DIFF
--- a/macros/get_problem_id.sql
+++ b/macros/get_problem_id.sql
@@ -3,5 +3,5 @@
 -- either the problem id is at the end of the object ID
 -- or is followed by '/answer' or '/hint'
 {% macro get_problem_id(object_id) %}
-   regexpExtract(object_id, 'xblock/([\w\d-@\+:]*)', 1)
+   regexpExtract(object_id, 'xblock/([\w\d-\+:]*@problem\+block@[\w\d][^_]*)(_\d_\d)?', 1)
 {% endmacro %}

--- a/models/problems/fact_problem_responses.sql
+++ b/models/problems/fact_problem_responses.sql
@@ -32,3 +32,18 @@ from
     join {{ ref('dim_course_blocks')}} blocks
          on (responses.course_key = blocks.course_key
              and responses.problem_id = blocks.block_id)
+group by
+    -- multi-part questions include an extra record for the response to the first
+    -- part of the question. this group by clause eliminates the duplicate record
+    emission_time,
+    org,
+    course_key,
+    course_name,
+    course_run,
+    problem_id,
+    problem_name,
+    problem_name_with_location,
+    actor_id,
+    responses,
+    success,
+    attempts


### PR DESCRIPTION
Responses to multi-part problems are currently excluded from `fact_problem_responses` because the regular expression for parsing problem IDs was incorrectly handling object IDs for distinct parts of problems. This PR changes the regular expression to accurately parse problem IDs while also removing duplicate problem response records (the first part in a multi-part question seems to have two records for every problem check event).