### PR TITLE
feat: add MV for transcript usage (FC-0033)

### DIFF
--- a/models/video/fact_transcript_usage.sql
+++ b/models/video/fact_transcript_usage.sql
@@ -1,17 +1,3 @@
-with transcripts as (
-    select
-        emission_time,
-        org,
-        splitByString('/', course_id)[-1] as course_key,
-        splitByString('/xblock/', object_id)[2] as video_id,
-        actor_id
-    from
-        {{ ref('xapi_events_all_parsed') }}
-    where
-        verb_id = 'http://adlnet.gov/expapi/verbs/interacted'
-        and JSON_VALUE(event_str, '$.result.extensions."https://w3id.org/xapi/video/extensions/cc-enabled"') = 'true'
-)
-
 select
     transcripts.emission_time as emission_time,
     transcripts.org as org,
@@ -23,7 +9,9 @@ select
     blocks.display_name_with_location as video_name_with_location,
     transcripts.actor_id as actor_id
 from
-    transcripts
+    {{ ref('video_transcript_events') }} transcripts
     join {{ ref('dim_course_blocks')}} blocks
          on (transcripts.course_key = blocks.course_key
              and transcripts.video_id = blocks.block_id)
+where
+    transcripts.cc_enabled

--- a/models/video/video_transcript_events.sql
+++ b/models/video/video_transcript_events.sql
@@ -1,0 +1,19 @@
+{{ config(
+    materialized='materialized_view',
+    engine='MergeTree()',
+    primary_key='(org, course_key, video_id)',
+    order_by='(org, course_key, video_id, emission_time, actor_id, cc_enabled, event_id)'
+  ) }}
+
+SELECT
+    event_id,
+    CAST(emission_time, 'DateTime') AS emission_time,
+    org,
+    splitByString('/', course_id)[-1] AS course_key,
+    splitByString('/xblock/', object_id)[2] as video_id,
+    actor_id,
+    JSONExtractBool(event_str, 'result','extensions','https://w3id.org/xapi/video/extensions/cc-enabled') as cc_enabled
+FROM {{ ref('xapi_events_all_parsed') }}
+WHERE
+    verb_id IN ('http://adlnet.gov/expapi/verbs/interacted')
+    AND JSONHas(event_str, 'result', 'extensions', 'https://w3id.org/xapi/video/extensions/cc-enabled')

--- a/models/video/video_transcript_events.sql
+++ b/models/video/video_transcript_events.sql
@@ -1,6 +1,6 @@
 {{ config(
     materialized='materialized_view',
-    engine='MergeTree()',
+    engine=get_engine('ReplacingMergeTree()'),
     primary_key='(org, course_key, video_id)',
     order_by='(org, course_key, video_id, emission_time, actor_id, cc_enabled, event_id)'
   ) }}


### PR DESCRIPTION
This update creates a new materialized view for transcript enabled/disabled events and updates `fact_transcript_usage` to use this new MV. This should improve the performance of transcript-related charts in Superset by avoiding relying on the base `xapi_events_all_parsed` table.