### PR TITLE
fix: write MVs to xapi schema again

### DIFF
--- a/macros/get_custom_schema.sql
+++ b/macros/get_custom_schema.sql
@@ -1,0 +1,3 @@
+{% macro generate_schema_name(custom_schema_name, node) -%}
+    {{ generate_schema_name_for_env(custom_schema_name, node) }}
+{%- endmacro %}

--- a/models/base/sources.yml
+++ b/models/base/sources.yml
@@ -2,7 +2,7 @@ version: 2
 
 sources:
   - name: xapi
-    database: "{{ env_var('XAPI_SCHEMA', 'xapi') }}"
+    database: "{{ env_var('ASPECTS_XAPI_DATABASE', 'xapi') }}"
     description: "the xapi database in clickhouse"
     tables:
       - name: xapi_events_all

--- a/models/base/xapi_events_all_parsed.sql
+++ b/models/base/xapi_events_all_parsed.sql
@@ -1,5 +1,6 @@
 {{ config(
     materialized='materialized_view',
+    schema=env_var('ASPECTS_XAPI_DATABASE', 'xapi'),
     engine=get_engine('ReplacingMergeTree()'),
     primary_key='(org, course_id, verb_id, actor_id, emission_time, event_id)',
     order_by='(org, course_id, verb_id, actor_id, emission_time, event_id)',

--- a/models/completion/completion_events.sql
+++ b/models/completion/completion_events.sql
@@ -1,5 +1,6 @@
 {{ config(
     materialized='materialized_view',
+    schema=env_var('ASPECTS_XAPI_DATABASE', 'xapi'),
     engine=get_engine('ReplacingMergeTree()'),
     primary_key='(org, course_key, verb_id)',
     order_by='(org, course_key, verb_id, emission_time, actor_id, object_id, event_id)'

--- a/models/enrollment/enrollment_events.sql
+++ b/models/enrollment/enrollment_events.sql
@@ -1,5 +1,6 @@
 {{ config(
     materialized='materialized_view',
+    schema=env_var('ASPECTS_XAPI_DATABASE', 'xapi'),
     engine=get_engine('ReplacingMergeTree()'),
     primary_key='(org, course_key)',
     order_by='(org, course_key, emission_time, actor_id, enrollment_mode, event_id)'

--- a/models/forum/forum_events.sql
+++ b/models/forum/forum_events.sql
@@ -1,5 +1,6 @@
 {{ config(
     materialized='materialized_view',
+    schema=env_var('ASPECTS_XAPI_DATABASE', 'xapi'),
     engine=get_engine('ReplacingMergeTree()'),
     primary_key='(org, course_key, verb_id)',
     order_by='(org, course_key, verb_id, emission_time, actor_id, object_id, event_id)'

--- a/models/grading/grading_events.sql
+++ b/models/grading/grading_events.sql
@@ -1,5 +1,6 @@
 {{ config(
     materialized='materialized_view',
+    schema=env_var('ASPECTS_XAPI_DATABASE', 'xapi'),
     engine=get_engine('ReplacingMergeTree()'),
     primary_key='(org, course_key, verb_id)',
     order_by='(org, course_key, verb_id, emission_time, actor_id, object_id, scaled_score, event_id)'

--- a/models/problems/problem_events.sql
+++ b/models/problems/problem_events.sql
@@ -1,5 +1,6 @@
 {{ config(
     materialized='materialized_view',
+    schema=env_var('ASPECTS_XAPI_DATABASE', 'xapi'),
     engine=get_engine('ReplacingMergeTree()'),
     primary_key='(org, course_key, verb_id)',
     order_by='(org, course_key, verb_id, emission_time, actor_id, object_id, responses, success, event_id)'

--- a/models/video/video_playback_events.sql
+++ b/models/video/video_playback_events.sql
@@ -1,5 +1,6 @@
 {{ config(
     materialized='materialized_view',
+    schema=env_var('ASPECTS_XAPI_DATABASE', 'xapi'),
     engine=get_engine('ReplacingMergeTree()'),
     primary_key='(org, course_key, verb_id)',
     order_by='(org, course_key, verb_id, emission_time, actor_id, video_position, event_id)'

--- a/models/video/video_transcript_events.sql
+++ b/models/video/video_transcript_events.sql
@@ -1,5 +1,6 @@
 {{ config(
     materialized='materialized_view',
+    schema=env_var('ASPECTS_XAPI_DATABASE', 'xapi'),
     engine=get_engine('ReplacingMergeTree()'),
     primary_key='(org, course_key, video_id)',
     order_by='(org, course_key, video_id, emission_time, actor_id, cc_enabled, event_id)'

--- a/sample_profiles.yml
+++ b/sample_profiles.yml
@@ -1,7 +1,7 @@
 aspects: # this needs to match the profile in your dbt_project.yml file
-  target: dev
+  target: prod
   outputs:
-    dev:
+    prod:
       type: clickhouse
       schema: xapi
       host: localhost


### PR DESCRIPTION
This change overrides the destination database for the materialized views that were once written to the `xapi` schema so that they can be written to the correct database again. Note: while `database` is the preferred term when it comes to dbt and ClickHouse, dbt does not seem to recognize `database` as a valid configuration parameter for model destinations, hence the use of the `schema` keyword argument in the `config` block.

This change also requires `profiles.yml` to pass `prod` as the target instead of `dev`. I have updated `sample_profiles.yml` to match the expected configuration. This also means that the [profile in tutor-contrib-aspects](https://github.com/openedx/tutor-contrib-aspects/blob/main/tutoraspects/templates/aspects/apps/aspects/dbt/profiles.yml#L2) will need to be updated as well.