### PR TITLE
feat: add models for navigation events (FC-0033)

### DIFF
--- a/models/navigation/fact_navigation.sql
+++ b/models/navigation/fact_navigation.sql
@@ -1,0 +1,18 @@
+select
+    navigation.emission_time as emission_time,
+    navigation.org as org,
+    navigation.course_key as course_key,
+    blocks.course_name as course_name,
+    blocks.course_run as course_run,
+    navigation.actor_id as actor_id,
+    navigation.block_id as block_id,
+    blocks.block_name as block_name,
+    blocks.display_name_with_location as block_name_with_location,
+    navigation.object_type as object_type,
+    navigation.starting_position as starting_position,
+    navigation.ending_point as ending_point
+from
+    {{ ref('navigation_events') }} navigation
+    join {{ ref('dim_course_blocks') }} blocks
+        on (navigation.course_key = blocks.course_key
+            and navigation.block_id = blocks.block_id)

--- a/models/navigation/navigation_events.sql
+++ b/models/navigation/navigation_events.sql
@@ -1,0 +1,38 @@
+{{ config(
+    materialized='materialized_view',
+    schema=env_var('ASPECTS_XAPI_DATABASE', 'xapi'),
+    engine=get_engine('ReplacingMergeTree()'),
+    primary_key='(org, course_key, object_type)',
+    order_by='(org, course_key, object_type, emission_time, actor_id, starting_position, event_id)'
+  ) }}
+
+SELECT
+    event_id,
+    cast(emission_time as DateTime) as emission_time,
+    actor_id,
+    splitByString('/xblock/', object_id)[-1] as block_id,
+    splitByString('/', course_id)[-1] AS course_key,
+    org,
+    verb_id,
+    JSONExtractString(event_str, 'object', 'definition', 'type') AS object_type,
+    -- clicking a link and selecting a module outline have no starting-position field
+    if (
+        object_type in (
+            'http://adlnet.gov/expapi/activities/link',
+            'http://adlnet.gov/expapi/activities/module'
+        ),
+        0,
+        JSONExtractInt(
+            event_str,
+            'context', 'extensions', 'http://id.tincanapi.com/extension/starting-position'
+        )
+    ) AS starting_position,
+    JSONExtractString(
+        event_str,
+        'context', 'extensions', 'http://id.tincanapi.com/extension/ending-point'
+    ) AS ending_point
+FROM
+    {{ ref('xapi_events_all_parsed') }}
+WHERE verb_id IN (
+    'https://w3id.org/xapi/dod-isd/verbs/navigated'
+)

--- a/models/navigation/schema.yml
+++ b/models/navigation/schema.yml
@@ -1,0 +1,60 @@
+version: 2
+
+models:
+  - name: navigation_events
+    description: "A materialized view for xAPI events related to course navigation"
+    columns:
+      - name: event_id
+        data_type: uuid
+      - name: emission_time
+        data_type: datetime
+        description: "Timestamp, to the second, of when this event was emitted"
+      - name: actor_id
+        data_type: string
+      - name: block_id
+        data_type: string
+      - name: course_key
+        data_type: string
+      - name: org
+        data_type: string
+      - name: verb_id
+        data_type: string
+      - name: object_type
+        data_type: string
+      - name: starting_position
+        data_type: int64
+        description: "The tab in the unit navigation bar that the learner was viewing before clicking a link"
+      - name: ending_point
+        data_type: string
+        description: "The tab in the unit navigation bar that the learner selected to navigate to"
+
+  - name: fact_navigation
+    description: "A view of navigation_events enriched with course and block metadata"
+    columns:
+      - name: emission_time
+        data_type: datetime
+        description: "Timestamp, to the second, of when this event was emitted"
+      - name: org
+        data_type: string
+      - name: course_key
+        data_type: string
+      - name: course_name
+        data_type: string
+      - name: course_run
+        data_type: string
+      - name: actor_id
+        data_type: string
+      - name: block_id
+        data_type: string
+      - name: block_name
+        data_type: string
+      - name: block_name_with_location
+        data_type: string
+      - name: object_type
+        data_type: string
+      - name: starting_position
+        data_type: int64
+        description: "The tab in the unit navigation bar that the learner was viewing before clicking a link"
+      - name: ending_point
+        data_type: string
+        description: "The tab in the unit navigation bar that the learner selected to navigate to"


### PR DESCRIPTION
This PR adds a materialized view for navigation events and an accompanying view that enriches the MV with course and block metadata.