### PR TITLE
feat!: Upgrade schema to use new Ralph 4.0 event column

### DIFF
--- a/models/base/sources.yml
+++ b/models/base/sources.yml
@@ -12,7 +12,6 @@ sources:
           - name: event_id
           - name: emission_time
           - name: event
-          - name: event_str
 
   - name: event_sink
     database: "{{ env_var('ASPECTS_EVENT_SINK_DATABASE', 'event_sink')}}"

--- a/models/base/xapi_events_all_parsed.sql
+++ b/models/base/xapi_events_all_parsed.sql
@@ -9,34 +9,34 @@
 
 SELECT
     event_id as event_id,
-    JSON_VALUE(event_str, '$.verb.id') as verb_id,
+    JSON_VALUE(event::String, '$.verb.id') as verb_id,
     COALESCE(
-        NULLIF(JSON_VALUE(event_str, '$.actor.account.name'), ''),
-        NULLIF(JSON_VALUE(event_str, '$.actor.mbox'), ''),
-        JSON_VALUE(event_str, '$.actor.mbox_sha1sum')
+        NULLIF(JSON_VALUE(event::String, '$.actor.account.name'), ''),
+        NULLIF(JSON_VALUE(event::String, '$.actor.mbox'), ''),
+        JSON_VALUE(event::String, '$.actor.mbox_sha1sum')
     ) as actor_id,
-    JSON_VALUE(event_str, '$.object.id') as object_id,
+    JSON_VALUE(event::String, '$.object.id') as object_id,
     -- If the contextActivities parent is a course, use that. It can be a "course"
     -- type, or a "cmi.interaction" type for multiple question problem submissions.
     -- Otherwise use the object id for the course id.
     multiIf(
         -- If the contextActivities parent is a course, use that
         JSON_VALUE(
-            event_str,
+            event::String,
             '$.context.contextActivities.parent[0].definition.type'
         ) = 'http://adlnet.gov/expapi/activities/course',
-        JSON_VALUE(event_str, '$.context.contextActivities.parent[0].id'),
+        JSON_VALUE(event::String, '$.context.contextActivities.parent[0].id'),
         -- Else if the contextActivities parent is a GroupActivity, it's a multi
         -- question problem and we use the grouping id
         JSON_VALUE(
-            event_str,
+            event::String,
             '$.context.contextActivities.parent[0].objectType'
         ) in ('Activity', 'GroupActivity'),
-        JSON_VALUE(event_str, '$.context.contextActivities.grouping[0].id'),
+        JSON_VALUE(event::String, '$.context.contextActivities.grouping[0].id'),
         -- Otherwise use the object id
-        JSON_VALUE(event_str, '$.object.id')
+        JSON_VALUE(event::String, '$.object.id')
     ) as course_id,
     coalesce(get_org_from_course_url(course_id), '') as org,
     emission_time as emission_time,
-    event_str as event_str
+    event::String as event
 FROM {{ source('xapi', 'xapi_events_all') }}

--- a/models/completion/completion_events.sql
+++ b/models/completion/completion_events.sql
@@ -14,6 +14,6 @@ SELECT
     splitByString('/', course_id)[-1] AS course_key,
     org,
     verb_id,
-    JSON_VALUE(event_str, '$.result.extensions."https://w3id.org/xapi/cmi5/result/extensions/progress"') AS progress_percent
+    JSON_VALUE(event, '$.result.extensions."https://w3id.org/xapi/cmi5/result/extensions/progress"') AS progress_percent
 FROM {{ ref('xapi_events_all_parsed') }}
 WHERE verb_id = 'http://adlnet.gov/expapi/verbs/progressed'

--- a/models/enrollment/enrollment_events.sql
+++ b/models/enrollment/enrollment_events.sql
@@ -14,7 +14,7 @@ SELECT
     splitByString('/', course_id)[-1] AS course_key,
     org,
     verb_id,
-    JSON_VALUE(event_str, '$.object.definition.extensions."https://w3id.org/xapi/acrossx/extensions/type"') AS enrollment_mode
+    JSON_VALUE(event, '$.object.definition.extensions."https://w3id.org/xapi/acrossx/extensions/type"') AS enrollment_mode
 FROM {{ ref('xapi_events_all_parsed') }}
 WHERE verb_id IN (
     'http://adlnet.gov/expapi/verbs/registered',

--- a/models/forum/forum_events.sql
+++ b/models/forum/forum_events.sql
@@ -15,4 +15,4 @@ SELECT
     actor_id,
     verb_id
 FROM {{ ref('xapi_events_all_parsed') }}
-WHERE JSON_VALUE(event_str, '$.object.definition.type') = 'http://id.tincanapi.com/activitytype/discussion'
+WHERE JSON_VALUE(event, '$.object.definition.type') = 'http://id.tincanapi.com/activitytype/discussion'

--- a/models/grading/grading_events.sql
+++ b/models/grading/grading_events.sql
@@ -15,6 +15,6 @@ SELECT
     splitByString('/', course_id)[-1] AS course_key,
     org,
     verb_id,
-    JSONExtractFloat(event_str, 'result', 'score', 'scaled') AS scaled_score
+    JSONExtractFloat(event, 'result', 'score', 'scaled') AS scaled_score
 FROM {{ ref('xapi_events_all_parsed') }}
 WHERE verb_id IN ('http://id.tincanapi.com/verb/earned', 'https://w3id.org/xapi/acrossx/verbs/evaluated')

--- a/models/navigation/navigation_events.sql
+++ b/models/navigation/navigation_events.sql
@@ -14,7 +14,7 @@ SELECT
     splitByString('/', course_id)[-1] AS course_key,
     org,
     verb_id,
-    JSONExtractString(event_str, 'object', 'definition', 'type') AS object_type,
+    JSONExtractString(event, 'object', 'definition', 'type') AS object_type,
     -- clicking a link and selecting a module outline have no starting-position field
     if (
         object_type in (
@@ -23,12 +23,12 @@ SELECT
         ),
         0,
         JSONExtractInt(
-            event_str,
+            event,
             'context', 'extensions', 'http://id.tincanapi.com/extension/starting-position'
         )
     ) AS starting_position,
     JSONExtractString(
-        event_str,
+        event,
         'context', 'extensions', 'http://id.tincanapi.com/extension/ending-point'
     ) AS ending_point
 FROM

--- a/models/problems/problem_events.sql
+++ b/models/problems/problem_events.sql
@@ -14,17 +14,17 @@ SELECT
     splitByString('/', course_id)[-1] AS course_key,
     org,
     verb_id,
-    JSON_VALUE(event_str, '$.result.response') as responses,
-    JSON_VALUE(event_str, '$.result.score.scaled') as scaled_score,
+    JSON_VALUE(event, '$.result.response') as responses,
+    JSON_VALUE(event, '$.result.score.scaled') as scaled_score,
     if(
         verb_id = 'https://w3id.org/xapi/acrossx/verbs/evaluated',
-        cast(JSON_VALUE(event_str, '$.result.success') as Bool),
+        cast(JSON_VALUE(event, '$.result.success') as Bool),
         false
     ) as success,
-    JSON_VALUE(event_str, '$.object.definition.interactionType') as interaction_type,
+    JSON_VALUE(event, '$.object.definition.interactionType') as interaction_type,
     if(
         verb_id = 'https://w3id.org/xapi/acrossx/verbs/evaluated',
-        cast(JSON_VALUE(event_str, '$.object.definition.extensions."http://id.tincanapi.com/extension/attempt-id"') as Int16),
+        cast(JSON_VALUE(event, '$.object.definition.extensions."http://id.tincanapi.com/extension/attempt-id"') as Int16),
         0
     ) as attempts
 FROM

--- a/models/video/video_playback_events.sql
+++ b/models/video/video_playback_events.sql
@@ -14,6 +14,6 @@ SELECT
     splitByString('/', course_id)[-1] AS course_key,
     org,
     verb_id,
-    ceil(CAST(coalesce(nullIf(JSON_VALUE(event_str, '$.result.extensions."https://w3id.org/xapi/video/extensions/time"'), ''), nullIf(JSON_VALUE(event_str, '$.result.extensions."https://w3id.org/xapi/video/extensions/time-from"'), ''), '0.0'), 'Decimal32(2)')) AS video_position
+    ceil(CAST(coalesce(nullIf(JSON_VALUE(event, '$.result.extensions."https://w3id.org/xapi/video/extensions/time"'), ''), nullIf(JSON_VALUE(event, '$.result.extensions."https://w3id.org/xapi/video/extensions/time-from"'), ''), '0.0'), 'Decimal32(2)')) AS video_position
 FROM {{ ref('xapi_events_all_parsed') }}
 WHERE (verb_id IN ('http://adlnet.gov/expapi/verbs/completed', 'http://adlnet.gov/expapi/verbs/initialized', 'http://adlnet.gov/expapi/verbs/terminated', 'https://w3id.org/xapi/video/verbs/paused', 'https://w3id.org/xapi/video/verbs/played', 'https://w3id.org/xapi/video/verbs/seeked')) AND (object_id LIKE '%video+block%')

--- a/models/video/video_transcript_events.sql
+++ b/models/video/video_transcript_events.sql
@@ -13,8 +13,8 @@ SELECT
     splitByString('/', course_id)[-1] AS course_key,
     splitByString('/xblock/', object_id)[2] as video_id,
     actor_id,
-    JSONExtractBool(event_str, 'result','extensions','https://w3id.org/xapi/video/extensions/cc-enabled') as cc_enabled
+    JSONExtractBool(event, 'result','extensions','https://w3id.org/xapi/video/extensions/cc-enabled') as cc_enabled
 FROM {{ ref('xapi_events_all_parsed') }}
 WHERE
     verb_id IN ('http://adlnet.gov/expapi/verbs/interacted')
-    AND JSONHas(event_str, 'result', 'extensions', 'https://w3id.org/xapi/video/extensions/cc-enabled')
+    AND JSONHas(event, 'result', 'extensions', 'https://w3id.org/xapi/video/extensions/cc-enabled')


### PR DESCRIPTION
Ralph 3.x had both a JSON "event" column and an
"event_str" text representation of the same data. 4.x drops the JSON column since it is unsupported and going to be removed from ClickHouse, and renames the text column to "event".

Ralph 4.0.0 is in beta right now, this is just for preparing to upgrade and test the changes.