### PR TITLE
fix: Bump dbt-clickhouse to 1.7.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-dbt-clickhouse==1.7.0
+dbt-clickhouse==1.7.2
 dbt-core==1.7.0


### PR DESCRIPTION
Fixes the issue with schemas of MVs being changed if they already exist.