### PR TITLE
feat: add support for CCX courses

### DIFF
--- a/macros/get_problem_id.sql
+++ b/macros/get_problem_id.sql
@@ -3,5 +3,5 @@
 -- either the problem id is at the end of the object ID
 -- or is followed by '/answer' or '/hint'
 {% macro get_problem_id(object_id) %}
-   regexpExtract(object_id, 'xblock/([\w\d-\+:]*@problem\+block@[\w\d][^_]*)(_\d_\d)?', 1)
+   regexpExtract(object_id, 'xblock/([\w\d-\+:@]*@problem\+block@[\w\d][^_]*)(_\d_\d)?', 1)
 {% endmacro %}

--- a/models/base/xapi_events_all_parsed.sql
+++ b/models/base/xapi_events_all_parsed.sql
@@ -37,7 +37,7 @@ SELECT
         -- Otherwise use the object id
         JSON_VALUE(event::String, '$.object.id')
     ) as course_id,
-    coalesce(get_org_from_course_url(course_id), '') as org,
+    coalesce(get_org_from_course_url(course_id), get_org_from_ccx_course_url(course_id), '') as org,
     emission_time as emission_time,
     event::String as event
 FROM {{ source('xapi', 'xapi_events_all') }}

--- a/tests/get_problem_id.sql
+++ b/tests/get_problem_id.sql
@@ -1,0 +1,6 @@
+select
+    'http://local.edly.io:8000/xblock/block-v1:edunext+demo+demo+ccx+type@problem+block@3c1646f7133a4c5fb4557d649e22c251' as object_id
+from
+    system.one
+where
+    {{ get_problem_id('object_id') }} != 'block-v1:edunext+demo+demo+ccx+type@problem+block@3c1646f7133a4c5fb4557d649e22c251'

--- a/tests/get_problem_id_with_ccx.sql
+++ b/tests/get_problem_id_with_ccx.sql
@@ -1,0 +1,6 @@
+select
+    'http://local.edly.io:8000/xblock/ccx-block-v1:edunext+demo+demo+ccx@1+type@problem+block@3c1646f7133a4c5fb4557d649e22c251' as object_id
+from
+    system.one
+where
+    {{ get_problem_id('object_id') }} != 'ccx-block-v1:edunext+demo+demo+ccx@1+type@problem+block@3c1646f7133a4c5fb4557d649e22c251'


### PR DESCRIPTION
### Description

This PR allows us to get the course organization for CCX courses and fixes the `get_problem_id` regex to include '@' which is part of the URL for CCX courses.

After querying: ` select * from reporting.fact_problem_responses format Vertical` it matches both course formats:

```
Row 3:
──────
emission_time:              2024-02-19 15:29:41
org:                        edunext
course_key:                 course-v1:edunext+demo+demo
course_name:                Demo
course_run:                 demo
problem_id:                 block-v1:edunext+demo+demo+type@problem+block@3c1646f7133a4c5fb4557d649e22c251
problem_name:               Checkboxes
problem_name_with_location: 2:2:0 - Checkboxes
actor_id:                   9bd74238-97cf-4bff-ab96-d98a6006cba5
responses:                  ["a correct answer", "a correct answer"]
success:                    true
attempts:                   1

Row 4:
──────
emission_time:              2024-02-16 22:15:14
org:                        edunext
course_key:                 ccx-v1:edunext+demo+demo+ccx@1
course_name:                demo CXX
course_run:                 ccx@1
problem_id:                 ccx-block-v1:edunext+demo+demo+ccx@1+type@problem+block@3c1646f7133a4c5fb4557d649e22c251
problem_name:               Checkboxes
problem_name_with_location: 2:2:0 - Checkboxes
actor_id:                   9bd74238-97cf-4bff-ab96-d98a6006cba5
responses:                  ["a correct answer", "an incorrect answer", "a correct answer"]
success:                    false
attempts:                   6

```

Depends on: https://github.com/openedx/tutor-contrib-aspects/pull/607