### PR TITLE
feat: order course blocks dictionary

### DIFF
--- a/models/base/most_recent_course_blocks.sql
+++ b/models/base/most_recent_course_blocks.sql
@@ -1,0 +1,30 @@
+{{
+    config(
+        materialized="materialized_view",
+        schema=env_var("ASPECTS_EVENT_SINK_DATABASE", "event_sink"),
+        engine=get_engine("ReplacingMergeTree()"),
+        primary_key=("location"),
+        order_by=("location"),
+        post_hook="OPTIMIZE TABLE {{ this }} {{ on_cluster() }} FINAL",
+    )
+}}
+
+select
+    location,
+    display_name,
+    toString(section)
+    || ':'
+    || toString(subsection)
+    || ':'
+    || toString(unit)
+    || ' - '
+    || display_name as display_name_with_location,
+    JSONExtractInt(xblock_data_json, 'section') as section,
+    JSONExtractInt(xblock_data_json, 'subsection') as subsection,
+    JSONExtractInt(xblock_data_json, 'unit') as unit,
+    JSONExtractBool(xblock_data_json, 'graded') as graded,
+    course_key,
+    dump_id,
+    time_last_dumped
+from {{ source("event_sink", "course_blocks") }}
+order by section, subsection, unit

--- a/models/base/sources.yml
+++ b/models/base/sources.yml
@@ -30,3 +30,15 @@ sources:
           - name: course_name
           - name: course_run
           - name: org
+
+      - name: course_blocks
+        columns:
+          - name: org
+          - name: course_key
+          - name: location
+          - name: display_name
+          - name: xblock_data_json
+          - name: order
+          - name: edited_on
+          - name: dump_id
+          - name: time_last_dumped


### PR DESCRIPTION
This PR migrates the [most_recent_course_blocks_mv](https://github.com/openedx/tutor-contrib-aspects/blob/main/tutoraspects/templates/aspects/apps/aspects/migrations/alembic/versions/0023_extend_display_names.py#L54-L112) from aspects to DBT.