### PR TITLE
feat: include models for pageview engagement

### DIFF
--- a/macros/parse_section_codes.sql
+++ b/macros/parse_section_codes.sql
@@ -1,0 +1,22 @@
+-- truncate a block's location code (e.g. '3:1:4') to the subsection level
+{% macro subsection_from_display(display_name_with_location) %}
+    concat(
+        arrayStringConcat(
+            splitByString(
+                ':', splitByString(' - ', {{ display_name_with_location }})[1], 2
+            ),
+            ':'
+        ),
+        ':0'
+    )
+{% endmacro %}
+
+-- truncate a block's location code (e.g. '3:1:4') to the section level
+{% macro section_from_display(display_name_with_location) %}
+    concat(
+        splitByString(
+            ':', splitByString(' - ', {{ display_name_with_location }})[1], 1
+        )[1],
+        ':0:0'
+    )
+{% endmacro %}

--- a/models/base/dim_course_blocks.sql
+++ b/models/base/dim_course_blocks.sql
@@ -5,6 +5,10 @@ select
     courses.course_run as course_run,
     blocks.location as block_id,
     blocks.block_name as block_name,
+    {{ section_from_display("blocks.display_name_with_location") }} as section_number,
+    {{ subsection_from_display("blocks.display_name_with_location") }}
+    as subsection_number,
+    splitByString(' - ', blocks.display_name_with_location)[1] as hierarchy_location,
     blocks.display_name_with_location as display_name_with_location,
     graded,
     case

--- a/models/base/schema.yml
+++ b/models/base/schema.yml
@@ -16,6 +16,15 @@ models:
         data_type: String
       - name: block_name
         data_type: String
+      - name: section_number
+        data_type: string
+        description: "The section this block belongs to, formatted as <section location>:0:0"
+      - name: subsection_number
+        data_type: string
+        description: "The subsection this block belongs to, formatted as <section location>:<subsection location>:0"
+      - name: hierarchy_location
+        data_type: string
+        description: "The full section:subsection:unit hierarchy in which this block belongs"
       - name: display_name_with_location
         data_type: String
         description: "The block's display name with section, subsection, and unit prepended to the name. This provides additional context when looking at block names and can help data consumers understand which block they are analyzing"

--- a/models/navigation/fact_navigation_completion.sql
+++ b/models/navigation/fact_navigation_completion.sql
@@ -1,0 +1,33 @@
+-- number of learners who've viewed all pages in a section/subsection
+with
+    visited_subsection_pages as (
+        select distinct
+            date(emission_time) as visited_on,
+            org,
+            course_key,
+            {{ section_from_display("block_name_with_location") }} as section_number,
+            {{ subsection_from_display("block_name_with_location") }}
+            as subsection_number,
+            actor_id,
+            block_id
+        from {{ ref("fact_navigation") }}
+    )
+
+select
+    visits.visited_on,
+    visits.org,
+    visits.course_key,
+    pages.section_with_name,
+    pages.subsection_with_name,
+    pages.page_count,
+    visits.actor_id,
+    visits.block_id
+from visited_subsection_pages visits
+join
+    {{ ref("int_pages_per_subsection") }} pages
+    on (
+        visits.org = pages.org
+        and visits.course_key = pages.course_key
+        and visits.section_number = pages.section_number
+        and visits.subsection_number = pages.subsection_number
+    )

--- a/models/navigation/fact_navigation_dropoff.sql
+++ b/models/navigation/fact_navigation_dropoff.sql
@@ -1,0 +1,75 @@
+with
+    blocks as (
+        select org, course_key, display_name_with_location, hierarchy_location
+        from {{ ref("dim_course_blocks") }}
+        where block_id like '%@chapter+block@%' or block_id like '%@sequential+block@%'
+    ),
+    page_views_by_section as (
+        -- section: x:0:0
+        -- take just the first number from the hierarchy location
+        select
+            date(emission_time) as emission_date,
+            org,
+            course_key,
+            {{ section_from_display("block_name_with_location") }} as section_number,
+            actor_id,
+            count(*) as total_views
+        from {{ ref("fact_navigation") }}
+        group by emission_date, org, course_key, section_number, actor_id
+    ),
+    page_views_by_subsection as (
+        -- subsection: x:y:0
+        -- take the first two numbers from the hierarchy location
+        select
+            date(emission_time) as emission_date,
+            org,
+            course_key,
+            {{ subsection_from_display("block_name_with_location") }}
+            as subsection_number,
+            actor_id,
+            count(*) as total_views
+        from {{ ref("fact_navigation") }}
+        group by emission_date, org, course_key, subsection_number, actor_id
+    ),
+    page_views as (
+        select
+            emission_date,
+            org,
+            course_key,
+            'section' as rollup_name,
+            section_number as hierarchy_location,
+            actor_id,
+            sum(total_views) as total_views
+        from page_views_by_section
+        group by
+            emission_date, org, course_key, rollup_name, hierarchy_location, actor_id
+        union all
+        select
+            emission_date,
+            org,
+            course_key,
+            'subsection' as rollup_name,
+            subsection_number as hierarchy_location,
+            actor_id,
+            sum(total_views) as total_views
+        from page_views_by_subsection
+        group by
+            emission_date, org, course_key, rollup_name, hierarchy_location, actor_id
+    )
+
+select
+    page_views.emission_date as emission_date,
+    page_views.org as org,
+    page_views.course_key as course_key,
+    page_views.rollup_name as rollup_name,
+    blocks.display_name_with_location as block_name,
+    page_views.actor_id as actor_id,
+    page_views.total_views as total_views
+from page_views
+join
+    blocks
+    on (
+        page_views.org = blocks.org
+        and page_views.course_key = blocks.course_key
+        and page_views.hierarchy_location = blocks.hierarchy_location
+    )

--- a/models/navigation/int_pages_per_subsection.sql
+++ b/models/navigation/int_pages_per_subsection.sql
@@ -1,0 +1,34 @@
+with
+    pages_per_subsection as (
+        select
+            org, course_key, section_number, subsection_number, count(*) as page_count
+        from {{ ref("dim_course_blocks") }}
+        where block_id like '%@vertical+block@%'
+        group by org, course_key, section_number, subsection_number
+    )
+
+select
+    pps.org as org,
+    pps.course_key as course_key,
+    pps.section_number as section_number,
+    section_blocks.display_name_with_location as section_with_name,
+    pps.subsection_number as subsection_number,
+    subsection_blocks.display_name_with_location as subsection_with_name,
+    pps.page_count as page_count
+from pages_per_subsection pps
+left join
+    {{ ref("dim_course_blocks") }} section_blocks
+    on (
+        pps.section_number = section_blocks.hierarchy_location
+        and pps.org = section_blocks.org
+        and pps.course_key = section_blocks.course_key
+        and section_blocks.block_id like '%@chapter+block@%'
+    )
+left join
+    {{ ref("dim_course_blocks") }} subsection_blocks
+    on (
+        pps.subsection_number = subsection_blocks.hierarchy_location
+        and pps.org = subsection_blocks.org
+        and pps.course_key = subsection_blocks.course_key
+        and subsection_blocks.block_id like '%@sequential+block@%'
+    )

--- a/models/navigation/schema.yml
+++ b/models/navigation/schema.yml
@@ -58,3 +58,48 @@ models:
       - name: ending_point
         data_type: string
         description: "The tab in the unit navigation bar that the learner selected to navigate to"
+
+  - name: fact_navigation_dropoff
+    description: "A view for analyzing the number of page visits per learner per section and subsection"
+    columns:
+      - name: emission_date
+        data_type: date
+      - name: org
+        data_type: string
+      - name: course_key
+        data_type: string
+      - name: rollup_name
+        data_type: string
+        description: "The level at which page views are counted"
+        tests:
+          - accepted_values:
+              values: ["section", "subsection"]
+      - name: block_name
+        data_type: string
+      - name: actor_id
+        data_type: string
+      - name: total_views
+        data_type: uint64
+        description: "The total number of times a learner viewed pages in this section or subsection on a given day"
+
+  - name: fact_navigation_completion
+    description: "A view for analyzing how many pages a learner has visited in a section or subsection"
+    columns:
+      - name: visited_on
+        data_type: date
+      - name: org
+        data_type: string
+      - name: course_key
+        data_type: string
+      - name: section_with_name
+        data_type: string
+      - name: subsection_with_name
+        data_type: string
+      - name: page_count
+        data_type: uint64
+        description: "The number of pages in the associated subsection"
+      - name: actor_id
+        data_type: string
+      - name: block_id
+        data_type: string
+        description: "The ID of the specific page visited"


### PR DESCRIPTION
This includes models to support engagement dropoff analyses and page view completeness, i.e. how many learners viewed all pages in a section or subsection.

`fact_navigation_dropoff` is a model with two different aggregation levels: total views are counted for each section and subsection.

`fact_navigation_completion` counts the number of pages in each section and subsection and joins that to data about page visits. Aggregations can use the `page_count` column to compare against the number of unique pages a learner has visited. If the numbers are equal, then the learner has visited every page in the section.

Here is an example query of how `fact_navigation_completeness` can answer the question "which learners viewed all pages in a subsection?":
```sql
SELECT
    subsection_with_name,
    actor_id,
    page_count,
    countDistinct(block_id) AS pages_visited,
    page_count = pages_visited AS visited_all_pages
FROM reporting.fact_navigation_completion
GROUP BY subsection_with_name, actor_id, page_count
HAVING visited_all_pages = 1
```