### PR TITLE
feat: implement fact_student_status model

### DIFF
--- a/.ci/config.yml
+++ b/.ci/config.yml
@@ -6,4 +6,6 @@ LMS_HOST: local.edly.io
 PLATFORM_NAME: Aspects Local CI Test
 PLUGINS:
 - aspects
-DOCKER_IMAGE_OPENEDX: edunext/openedx-aspects:0.80.0
+DOCKER_IMAGE_OPENEDX: edunext/openedx-aspects:latest
+DOCKER_IMAGE_ASPECTS: edunext/aspects:latest
+DOCKER_IMAGE_SUPERSET: edunext/aspects-superset:latest

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -50,7 +50,7 @@ jobs:
         run: |
           dbt run
           dbt docs generate
-          dbt-coverage compute doc --cov-fail-under 0.9
+          dbt-coverage compute doc --cov-fail-under 1.0
       - name: Deploy
         if: github.event_name == 'push'
         uses: peaceiris/actions-gh-pages@v3

--- a/models/base/dim_user_pii.sql
+++ b/models/base/dim_user_pii.sql
@@ -1,0 +1,16 @@
+select
+    external_user_id,
+    external_id_type,
+    username,
+    name,
+    language,
+    year_of_birth,
+    gender,
+    level_of_education,
+    country,
+    if(
+        toInt32OrZero(year_of_birth) = 0,
+        NULL,
+        toYear(now()) - toInt32OrZero(year_of_birth)
+    ) as age
+from {{ source("event_sink", "user_pii") }} user_pii

--- a/models/base/schema.yml
+++ b/models/base/schema.yml
@@ -41,6 +41,30 @@ models:
         data_type: String
         description: "The type of block. This can be a section, subsection, unit, or the block type"
 
+  - name: user_pii
+    description: "The user PII table for reports."
+    columns:
+      - name: external_user_id
+        description: "The external user id"
+      - name: external_id_type
+        description: "The external id type"
+      - name: username
+        description: "The username"
+      - name: name
+        description: "The name of the user"
+      - name: language
+        description: "The language of the user"
+      - name: year_of_birth
+        description: "The year of birth of the user"
+      - name: gender
+        description: "The gender of the user"
+      - name: level_of_education
+        description: "The level of education of the user"
+      - name: country
+        description: "The country of the user"
+      - name: age
+        description: "The age of the user"
+
   - name: xapi_events_all_parsed
     description: "A materialized view for xAPI events"
     columns:

--- a/models/base/schema.yml
+++ b/models/base/schema.yml
@@ -92,3 +92,37 @@ models:
       - name: event
         data_type: string
         description: "The xAPI event as a string"
+
+  - name: dim_user_pii
+    description: "A denormalized table of user PII information"
+    columns:
+      - name: external_user_id
+        data_type: String
+        description: "The external user id"
+      - name: external_id_type
+        data_type: String
+        description: "The external id type"
+      - name: username
+        data_type: String
+        description: "The username"
+      - name: name
+        data_type: String
+        description: "The name of the user"
+      - name: language
+        data_type: String
+        description: "The language of the user"
+      - name: year_of_birth
+        data_type: Int
+        description: "The year of birth of the user"
+      - name: gender
+        data_type: String
+        description: "The gender of the user"
+      - name: level_of_education
+        data_type: String
+        description: "The level of education of the user"
+      - name: country
+        data_type: String
+        description: "The country of the user"
+      - name: age
+        data_type: Int
+        description: "The age of the user"

--- a/models/base/sources.yml
+++ b/models/base/sources.yml
@@ -30,3 +30,46 @@ sources:
           - name: course_name
           - name: course_run
           - name: org
+
+      - name: user_pii
+        columns:
+          - name: user_id
+            description: "The user id"
+          - name: external_user_id
+            description: "The external user id"
+          - name: external_id_type
+            description: "The external id type"
+          - name: username
+            description: "The username"
+          - name: name
+            description: "The name of the user"
+          - name: meta
+            description: "A field to store custom information as JSON"
+          - name: courseware
+            description: "Unknown"
+          - name: language
+            description: "The language of the user"
+          - name: location
+            description: "Unknown"
+          - name: year_of_birth
+            description: "The year of birth of the user"
+          - name: gender
+            description: "The gender of the user"
+          - name: level_of_education
+            description: "The level of education of the user"
+          - name: mailing_address
+            description: "The mailing address of the user"
+          - name: city
+            description: "The city of the user"
+          - name: country
+            description: "The country of the user"
+          - name: state
+            description: "The state of the user"
+          - name: goals
+            description: "The goals of the user"
+          - name: bio
+            description: "The bio of the user"
+          - name: profile_image_uploaded_at
+            description: "Date of the profile image upload"
+          - name: phone_number
+            description: "The phone number of the user"

--- a/models/enrollment/fact_enrollment_status.sql
+++ b/models/enrollment/fact_enrollment_status.sql
@@ -13,7 +13,7 @@ with
             emission_time,
             org,
             course_key,
-            splitByString('+\\', course_key)[-1] as course_run,
+            splitByString('+', course_key)[-1] as course_run,
             actor_id,
             enrollment_mode,
             splitByString('/', verb_id)[-1] as enrollment_status,

--- a/models/enrollment/fact_enrollment_status.sql
+++ b/models/enrollment/fact_enrollment_status.sql
@@ -22,6 +22,6 @@ with
         from {{ ref("enrollment_events") }}
     )
 
-select org, course_key, actor_id, enrollment_status
+select org, course_key, actor_id, enrollment_status, emission_time
 from ranked_enrollments
 where rn = 1

--- a/models/enrollment/fact_enrollment_status.sql
+++ b/models/enrollment/fact_enrollment_status.sql
@@ -18,11 +18,19 @@ with
             enrollment_mode,
             splitByString('/', verb_id)[-1] as enrollment_status,
             row_number() over (
-                partition by org, course_key, course_run, actor_id order by emission_time desc
+                partition by org, course_key, course_run, actor_id
+                order by emission_time desc
             ) as rn
         from {{ ref("enrollment_events") }}
     )
 
-select org, course_key, course_run, actor_id, enrollment_status, enrollment_mode, emission_time
+select
+    org,
+    course_key,
+    course_run,
+    actor_id,
+    enrollment_status,
+    enrollment_mode,
+    emission_time
 from ranked_enrollments
 where rn = 1

--- a/models/enrollment/fact_enrollment_status.sql
+++ b/models/enrollment/fact_enrollment_status.sql
@@ -17,18 +17,11 @@ with
             enrollment_mode,
             splitByString('/', verb_id)[-1] as enrollment_status,
             row_number() over (
-                partition by org, course_key, actor_id
-                order by emission_time desc
+                partition by org, course_key, actor_id order by emission_time desc
             ) as rn
         from {{ ref("enrollment_events") }}
     )
 
-select
-    org,
-    course_key,
-    actor_id,
-    enrollment_status,
-    enrollment_mode,
-    emission_time
+select org, course_key, actor_id, enrollment_status, enrollment_mode, emission_time
 from ranked_enrollments
 where rn = 1

--- a/models/enrollment/fact_enrollment_status.sql
+++ b/models/enrollment/fact_enrollment_status.sql
@@ -1,0 +1,27 @@
+{{
+    config(
+        materialized="materialized_view",
+        engine=get_engine("ReplacingMergeTree()"),
+        primary_key="(org, course_key, actor_id)",
+        order_by="(org, course_key, actor_id)",
+    )
+}}
+
+with
+    ranked_enrollments as (
+        select
+            emission_time,
+            org,
+            course_key,
+            actor_id,
+            enrollment_mode,
+            splitByString('/', verb_id)[-1] as enrollment_status,
+            row_number() over (
+                partition by org, course_key, actor_id order by emission_time desc
+            ) as rn
+        from {{ ref("enrollment_events") }}
+    )
+
+select org, course_key, actor_id, enrollment_status
+from ranked_enrollments
+where rn = 1

--- a/models/enrollment/fact_enrollment_status.sql
+++ b/models/enrollment/fact_enrollment_status.sql
@@ -2,8 +2,8 @@
     config(
         materialized="materialized_view",
         engine=get_engine("ReplacingMergeTree()"),
-        primary_key="(org, course_key, actor_id)",
-        order_by="(org, course_key, actor_id)",
+        primary_key="(org, course_key, course_run, actor_id)",
+        order_by="(org, course_key, course_run, actor_id)",
     )
 }}
 
@@ -13,15 +13,16 @@ with
             emission_time,
             org,
             course_key,
+            splitByString('+\\', course_key)[-1] as course_run,
             actor_id,
             enrollment_mode,
             splitByString('/', verb_id)[-1] as enrollment_status,
             row_number() over (
-                partition by org, course_key, actor_id order by emission_time desc
+                partition by org, course_key, course_run, actor_id order by emission_time desc
             ) as rn
         from {{ ref("enrollment_events") }}
     )
 
-select org, course_key, actor_id, enrollment_status, emission_time
+select org, course_key, course_run, actor_id, enrollment_status, enrollment_mode, emission_time
 from ranked_enrollments
 where rn = 1

--- a/models/enrollment/fact_enrollment_status.sql
+++ b/models/enrollment/fact_enrollment_status.sql
@@ -2,8 +2,8 @@
     config(
         materialized="materialized_view",
         engine=get_engine("ReplacingMergeTree()"),
-        primary_key="(org, course_key, course_run, actor_id)",
-        order_by="(org, course_key, course_run, actor_id)",
+        primary_key="(org, course_key, actor_id)",
+        order_by="(org, course_key, actor_id)",
     )
 }}
 
@@ -13,12 +13,11 @@ with
             emission_time,
             org,
             course_key,
-            splitByString('+', course_key)[-1] as course_run,
             actor_id,
             enrollment_mode,
             splitByString('/', verb_id)[-1] as enrollment_status,
             row_number() over (
-                partition by org, course_key, course_run, actor_id
+                partition by org, course_key, actor_id
                 order by emission_time desc
             ) as rn
         from {{ ref("enrollment_events") }}
@@ -27,7 +26,6 @@ with
 select
     org,
     course_key,
-    course_run,
     actor_id,
     enrollment_status,
     enrollment_mode,

--- a/models/enrollment/schema.yml
+++ b/models/enrollment/schema.yml
@@ -69,9 +69,6 @@ models:
       - name: course_key
         data_type: string
         description: "The course key for the course"
-      - name: course_run
-        data_type: string
-        description: "The course run for the course"
       - name: actor_id
         data_type: string
         description: "The xAPI actor identifier"

--- a/models/enrollment/schema.yml
+++ b/models/enrollment/schema.yml
@@ -78,3 +78,6 @@ models:
         tests:
           - accepted_values:
               values: ["registered", "unregistered"]
+      - name: emission_time
+        data_type: datetime
+        description: "The time the enrollment status was emitted"

--- a/models/enrollment/schema.yml
+++ b/models/enrollment/schema.yml
@@ -59,3 +59,22 @@ models:
       - name: enrollment_mode
         data_type: string
         description: "The mode of enrollment"
+
+  - name: fact_enrollment_status
+    description: One record per learner per course for the most recent enrollment status
+    columns:
+      - name: org
+        data_type: string
+        description: "The organization that the course belongs to"
+      - name: course_key
+        data_type: string
+        description: "The course key for the course"
+      - name: actor_id
+        data_type: string
+        description: "The xAPI actor identifier"
+      - name: enrollment_status
+        data_type: string
+        description: "Whether a learner is actively enrolled in a course"
+        tests:
+          - accepted_values:
+              values: ["registered", "unregistered"]

--- a/models/enrollment/schema.yml
+++ b/models/enrollment/schema.yml
@@ -69,6 +69,9 @@ models:
       - name: course_key
         data_type: string
         description: "The course key for the course"
+      - name: course_run
+        data_type: string
+        description: "The course run for the course"
       - name: actor_id
         data_type: string
         description: "The xAPI actor identifier"
@@ -78,6 +81,9 @@ models:
         tests:
           - accepted_values:
               values: ["registered", "unregistered"]
+      - name: enrollment_mode
+        data_type: string
+        description: "The mode of enrollment"
       - name: emission_time
         data_type: datetime
         description: "The time the enrollment status was emitted"

--- a/models/forum/schema.yml
+++ b/models/forum/schema.yml
@@ -33,7 +33,7 @@ models:
         description: "The xAPI verb identifier"
 
   - name: forum_events
-    description: ""
+    description: "One record per forum event"
     columns:
       - name: event_id
         data_type: uuid

--- a/models/grading/fact_grade_status.sql
+++ b/models/grading/fact_grade_status.sql
@@ -5,6 +5,7 @@ select
     courses.course_name as course_name,
     courses.course_run as course_run,
     coalesce(state, 'failed') as state,
+    emission_time,
     course_grade as course_grade,
     {{ get_bucket("course_grade") }} as grade_bucket
 from {{ ref("fact_learner_course_grade") }} ls

--- a/models/grading/fact_learner_course_grade.sql
+++ b/models/grading/fact_learner_course_grade.sql
@@ -16,8 +16,7 @@ with
             actor_id,
             scaled_score as course_grade,
             row_number() over (
-                partition by org, course_key, actor_id
-                order by emission_time desc
+                partition by org, course_key, actor_id order by emission_time desc
             ) as rn
         from {{ ref("grading_events") }}
         where object_id like '%/course/%'

--- a/models/grading/fact_learner_course_grade.sql
+++ b/models/grading/fact_learner_course_grade.sql
@@ -17,7 +17,8 @@ with
             actor_id,
             scaled_score as course_grade,
             row_number() over (
-                partition by org, course_key, course_run, actor_id order by emission_time desc
+                partition by org, course_key, course_run, actor_id
+                order by emission_time desc
             ) as rn
         from {{ ref("grading_events") }}
         where object_id like '%/course/%'

--- a/models/grading/fact_learner_course_grade.sql
+++ b/models/grading/fact_learner_course_grade.sql
@@ -2,8 +2,8 @@
     config(
         materialized="materialized_view",
         engine=get_engine("ReplacingMergeTree()"),
-        primary_key="(org, course_key, actor_id)",
-        order_by="(org, course_key, actor_id)",
+        primary_key="(org, course_key, course_run, actor_id)",
+        order_by="(org, course_key, course_run, actor_id)",
     )
 }}
 
@@ -13,15 +13,16 @@ with
             emission_time,
             org,
             course_key,
+            splitByString('+\\', course_key)[-1] as course_run,
             actor_id,
             scaled_score as course_grade,
             row_number() over (
-                partition by org, course_key, actor_id order by emission_time desc
+                partition by org, course_key, course_run, actor_id order by emission_time desc
             ) as rn
         from {{ ref("grading_events") }}
         where object_id like '%/course/%'
     )
 
-select org, course_key, actor_id, course_grade, emission_time
+select org, course_key, course_run, actor_id, course_grade, emission_time
 from ranked_grades
 where rn = 1

--- a/models/grading/fact_learner_course_grade.sql
+++ b/models/grading/fact_learner_course_grade.sql
@@ -10,6 +10,7 @@
 with
     ranked_grades as (
         select
+            emission_time,
             org,
             course_key,
             actor_id,
@@ -21,6 +22,6 @@ with
         where object_id like '%/course/%'
     )
 
-select org, course_key, actor_id, course_grade
+select org, course_key, actor_id, course_grade, emission_time
 from ranked_grades
 where rn = 1

--- a/models/grading/fact_learner_course_grade.sql
+++ b/models/grading/fact_learner_course_grade.sql
@@ -13,7 +13,7 @@ with
             emission_time,
             org,
             course_key,
-            splitByString('+\\', course_key)[-1] as course_run,
+            splitByString('+', course_key)[-1] as course_run,
             actor_id,
             scaled_score as course_grade,
             row_number() over (

--- a/models/grading/fact_learner_course_grade.sql
+++ b/models/grading/fact_learner_course_grade.sql
@@ -2,8 +2,8 @@
     config(
         materialized="materialized_view",
         engine=get_engine("ReplacingMergeTree()"),
-        primary_key="(org, course_key, course_run, actor_id)",
-        order_by="(org, course_key, course_run, actor_id)",
+        primary_key="(org, course_key, actor_id)",
+        order_by="(org, course_key, actor_id)",
     )
 }}
 
@@ -13,17 +13,16 @@ with
             emission_time,
             org,
             course_key,
-            splitByString('+', course_key)[-1] as course_run,
             actor_id,
             scaled_score as course_grade,
             row_number() over (
-                partition by org, course_key, course_run, actor_id
+                partition by org, course_key, actor_id
                 order by emission_time desc
             ) as rn
         from {{ ref("grading_events") }}
         where object_id like '%/course/%'
     )
 
-select org, course_key, course_run, actor_id, course_grade, emission_time
+select org, course_key, actor_id, course_grade, emission_time
 from ranked_grades
 where rn = 1

--- a/models/grading/fact_learner_course_status.sql
+++ b/models/grading/fact_learner_course_status.sql
@@ -16,8 +16,7 @@ with
             splitByString('/', verb_id)[-1] as approving_state,
             emission_time,
             row_number() over (
-                partition by org, course_key, actor_id
-                order by emission_time desc
+                partition by org, course_key, actor_id order by emission_time desc
             ) as rn
         from {{ ref("grading_events") }}
         where

--- a/models/grading/fact_learner_course_status.sql
+++ b/models/grading/fact_learner_course_status.sql
@@ -2,8 +2,8 @@
     config(
         materialized="materialized_view",
         engine=get_engine("ReplacingMergeTree()"),
-        primary_key="(org, course_key, course_run, actor_id)",
-        order_by="(org, course_key, course_run, actor_id)",
+        primary_key="(org, course_key, actor_id)",
+        order_by="(org, course_key, actor_id)",
     )
 }}
 
@@ -14,10 +14,9 @@ with
             course_key,
             actor_id,
             splitByString('/', verb_id)[-1] as approving_state,
-            splitByString('+', course_key)[-1] as course_run,
             emission_time,
             row_number() over (
-                partition by org, course_key, course_run, actor_id
+                partition by org, course_key, actor_id
                 order by emission_time desc
             ) as rn
         from {{ ref("grading_events") }}
@@ -28,6 +27,6 @@ with
             )
     )
 
-select org, course_key, course_run, actor_id, approving_state, emission_time
+select org, course_key, actor_id, approving_state, emission_time
 from ranked_status
 where rn = 1

--- a/models/grading/fact_learner_course_status.sql
+++ b/models/grading/fact_learner_course_status.sql
@@ -17,7 +17,8 @@ with
             splitByString('+', course_key)[-1] as course_run,
             emission_time,
             row_number() over (
-                partition by org, course_key, course_run, actor_id order by emission_time desc
+                partition by org, course_key, course_run, actor_id
+                order by emission_time desc
             ) as rn
         from {{ ref("grading_events") }}
         where

--- a/models/grading/fact_learner_course_status.sql
+++ b/models/grading/fact_learner_course_status.sql
@@ -2,8 +2,8 @@
     config(
         materialized="materialized_view",
         engine=get_engine("ReplacingMergeTree()"),
-        primary_key="(org, course_key, actor_id)",
-        order_by="(org, course_key, actor_id)",
+        primary_key="(org, course_key, course_run, actor_id)",
+        order_by="(org, course_key, course_run, actor_id)",
     )
 }}
 
@@ -13,10 +13,11 @@ with
             org,
             course_key,
             actor_id,
-            splitByString('/', verb_id)[-1] as state,
+            splitByString('/', verb_id)[-1] as approving_state,
+            splitByString('+\\', course_key)[-1] as course_run,
             emission_time,
             row_number() over (
-                partition by org, course_key, actor_id order by emission_time desc
+                partition by org, course_key, course_run, actor_id order by emission_time desc
             ) as rn
         from {{ ref("grading_events") }}
         where
@@ -26,6 +27,6 @@ with
             )
     )
 
-select org, course_key, actor_id, state, emission_time
+select org, course_key, course_run, actor_id, approving_state, emission_time
 from ranked_status
 where rn = 1

--- a/models/grading/fact_learner_course_status.sql
+++ b/models/grading/fact_learner_course_status.sql
@@ -14,7 +14,7 @@ with
             course_key,
             actor_id,
             splitByString('/', verb_id)[-1] as approving_state,
-            splitByString('+\\', course_key)[-1] as course_run,
+            splitByString('+', course_key)[-1] as course_run,
             emission_time,
             row_number() over (
                 partition by org, course_key, course_run, actor_id order by emission_time desc

--- a/models/grading/fact_learner_course_status.sql
+++ b/models/grading/fact_learner_course_status.sql
@@ -14,6 +14,7 @@ with
             course_key,
             actor_id,
             splitByString('/', verb_id)[-1] as state,
+            emission_time,
             row_number() over (
                 partition by org, course_key, actor_id order by emission_time desc
             ) as rn
@@ -25,6 +26,6 @@ with
             )
     )
 
-select org, course_key, actor_id, state
+select org, course_key, actor_id, state, emission_time
 from ranked_status
 where rn = 1

--- a/models/grading/fact_student_status.sql
+++ b/models/grading/fact_student_status.sql
@@ -17,7 +17,7 @@ left join
     and fes.actor_id = lg.actor_id
 left join
     {{ ref("fact_learner_course_grade") }} ls
-    on fes.org = fes.org
+    on fes.org = ls.org
     and fes.course_key = ls.course_key
     and fes.actor_id = ls.actor_id
 join

--- a/models/grading/fact_student_status.sql
+++ b/models/grading/fact_student_status.sql
@@ -4,7 +4,6 @@ select
     ls.course_run as course_run,
     ls.actor_id as actor_id,
     courses.course_name as course_name,
-    courses.course_run as course_run,
     coalesce(approving_state, 'failed') as approving_state,
     enrollment_mode,
     enrollment_status,

--- a/models/grading/fact_student_status.sql
+++ b/models/grading/fact_student_status.sql
@@ -4,7 +4,7 @@ select
     fes.course_run as course_run,
     fes.actor_id as actor_id,
     courses.course_name as course_name,
-    coalesce(approving_state, 'failed') as approving_state,
+    if(empty(approving_state), 'failed', approving_state) as approving_state,
     enrollment_mode,
     enrollment_status,
     course_grade as course_grade,

--- a/models/grading/fact_student_status.sql
+++ b/models/grading/fact_student_status.sql
@@ -6,7 +6,7 @@ select
     courses.course_run as course_run,
     coalesce(state, 'failed') as state,
     enrollment_status,
-    lg.emission_time,
+    lg.emission_time as emission_time,
     course_grade as course_grade,
     {{ get_bucket("course_grade") }} as grade_bucket
 from {{ ref("fact_learner_course_grade") }} ls

--- a/models/grading/fact_student_status.sql
+++ b/models/grading/fact_student_status.sql
@@ -1,10 +1,12 @@
 select
     ls.org as org,
     ls.course_key as course_key,
+    ls.course_run as course_run,
     ls.actor_id as actor_id,
     courses.course_name as course_name,
     courses.course_run as course_run,
-    coalesce(state, 'failed') as state,
+    coalesce(approving_state, 'failed') as approving_state,
+    enrollment_mode,
     enrollment_status,
     course_grade as course_grade,
     {{ get_bucket("course_grade") }} as grade_bucket

--- a/models/grading/fact_student_status.sql
+++ b/models/grading/fact_student_status.sql
@@ -6,7 +6,6 @@ select
     courses.course_run as course_run,
     coalesce(state, 'failed') as state,
     enrollment_status,
-    lg.emission_time as emission_time,
     course_grade as course_grade,
     {{ get_bucket("course_grade") }} as grade_bucket
 from {{ ref("fact_learner_course_grade") }} ls

--- a/models/grading/fact_student_status.sql
+++ b/models/grading/fact_student_status.sql
@@ -1,9 +1,9 @@
 select
     fes.org as org,
     fes.course_key as course_key,
-    fes.course_run as course_run,
     fes.actor_id as actor_id,
     courses.course_name as course_name,
+    courses.course_run as course_run,
     if(empty(approving_state), 'failed', approving_state) as approving_state,
     enrollment_mode,
     enrollment_status,
@@ -14,16 +14,13 @@ left join
     {{ ref("fact_learner_course_status") }} lg
     on fes.org = lg.org
     and fes.course_key = lg.course_key
-    and fes.course_run = lg.course_run
     and fes.actor_id = lg.actor_id
 left join
     {{ ref("fact_learner_course_grade") }} ls
     on fes.org = fes.org
     and fes.course_key = ls.course_key
-    and fes.course_run = ls.course_run
     and fes.actor_id = ls.actor_id
 join
     {{ source("event_sink", "course_names") }} courses
     on fes.org = courses.org
     and fes.course_key = courses.course_key
-    and fes.course_run = courses.course_run

--- a/models/grading/fact_student_status.sql
+++ b/models/grading/fact_student_status.sql
@@ -1,29 +1,29 @@
 select
-    ls.org as org,
-    ls.course_key as course_key,
-    ls.course_run as course_run,
-    ls.actor_id as actor_id,
+    fes.org as org,
+    fes.course_key as course_key,
+    fes.course_run as course_run,
+    fes.actor_id as actor_id,
     courses.course_name as course_name,
     coalesce(approving_state, 'failed') as approving_state,
     enrollment_mode,
     enrollment_status,
     course_grade as course_grade,
     {{ get_bucket("course_grade") }} as grade_bucket
-from {{ ref("fact_learner_course_grade") }} ls
+from {{ ref("fact_enrollment_status") }} fes
 left join
     {{ ref("fact_learner_course_status") }} lg
-    on ls.org = lg.org
-    and ls.course_key = lg.course_key
-    and ls.course_run = lg.course_run
-    and ls.actor_id = lg.actor_id
+    on fes.org = lg.org
+    and fes.course_key = lg.course_key
+    and fes.course_run = lg.course_run
+    and fes.actor_id = lg.actor_id
 left join
-    {{ ref("fact_enrollment_status") }} fes
-    on ls.org = fes.org
-    and ls.course_key = fes.course_key
-    and ls.course_run = fes.course_run
-    and ls.actor_id = fes.actor_id
+    {{ ref("fact_learner_course_grade") }} ls
+    on fes.org = fes.org
+    and fes.course_key = ls.course_key
+    and fes.course_run = ls.course_run
+    and fes.actor_id = ls.actor_id
 join
     {{ source("event_sink", "course_names") }} courses
-    on ls.org = courses.org
-    and ls.course_key = courses.course_key
-    and ls.course_run = courses.course_run
+    on fes.org = courses.org
+    and fes.course_key = courses.course_key
+    and fes.course_run = courses.course_run

--- a/models/grading/fact_student_status.sql
+++ b/models/grading/fact_student_status.sql
@@ -13,12 +13,16 @@ left join
     {{ ref("fact_learner_course_status") }} lg
     on ls.org = lg.org
     and ls.course_key = lg.course_key
+    and ls.course_run = lg.course_run
     and ls.actor_id = lg.actor_id
 left join
     {{ ref("fact_enrollment_status") }} fes
     on ls.org = fes.org
     and ls.course_key = fes.course_key
+    and ls.course_run = fes.course_run
     and ls.actor_id = fes.actor_id
 join
     {{ source("event_sink", "course_names") }} courses
-    on ls.course_key = courses.course_key
+    on ls.org = courses.org
+    and ls.course_key = courses.course_key
+    and ls.course_run = courses.course_run

--- a/models/grading/fact_student_status.sql
+++ b/models/grading/fact_student_status.sql
@@ -5,7 +5,8 @@ select
     courses.course_name as course_name,
     courses.course_run as course_run,
     coalesce(state, 'failed') as state,
-    emission_time,
+    enrollment_status,
+    lg.emission_time,
     course_grade as course_grade,
     {{ get_bucket("course_grade") }} as grade_bucket
 from {{ ref("fact_learner_course_grade") }} ls
@@ -14,6 +15,11 @@ left join
     on ls.org = lg.org
     and ls.course_key = lg.course_key
     and ls.actor_id = lg.actor_id
+left join
+    {{ ref("fact_enrollment_status") }} fes
+    on ls.org = fes.org
+    and ls.course_key = fes.course_key
+    and ls.actor_id = fes.actor_id
 join
     {{ source("event_sink", "course_names") }} courses
     on ls.course_key = courses.course_key

--- a/models/grading/schema.yml
+++ b/models/grading/schema.yml
@@ -126,6 +126,9 @@ models:
       - name: course_key
         data_type: string
         description: "The course key for the course"
+      - name: course_run
+        data_type: string
+        description: "The course run"
       - name: actor_id
         data_type: string
         description: "The xAPI actor identifier"
@@ -135,9 +138,12 @@ models:
       - name: course_run
         data_type: string
         description: "The course run for the course"
-      - name: state
+      - name: approving_state
         data_type: string
         description: "The most recent approving state for the learner"
+      - name: enrollment_mode
+        data_type: string
+        description: "The mode of enrollment"
       - name: enrollment_status
         description: "Whether a learner is actively enrolled in a course"
         tests:

--- a/models/grading/schema.yml
+++ b/models/grading/schema.yml
@@ -44,37 +44,6 @@ models:
         description: "A displayable value of grades sorted into 10% buckets. Useful for grouping grades together to show high-level learner performance"
         data_type: String
 
-  - name: fact_grade_status
-    description: "One record per learner per course for the most recent grade and approving status"
-    columns:
-      - name: org
-        data_type: String
-        description: "The organization that the course belongs to"
-      - name: course_key
-        data_type: String
-        description: "The course key for the course"
-      - name: actor_id
-        data_type: String
-        description: "The xAPI actor identifier"
-      - name: course_name
-        data_type: String
-        description: "The name of the course"
-      - name: course_run
-        data_type: String
-        description: "The course run for the course"
-      - name: state
-        description: "The most recent state of the learner's grade"
-        tests:
-          - accepted_values:
-              values: ["passed", "failed"]
-        data_type: String
-      - name: course_grade
-        description: "The most recent grade for the learner"
-        data_type: Float32
-      - name: grade_bucket
-        description: "A displayable value of grades sorted into 10% buckets. Useful for grouping grades together to show high-level learner performance"
-        data_type: String
-
   - name: fact_learner_course_grade
     description: "One record per learner per course for the most recent grade"
     columns:
@@ -103,6 +72,9 @@ models:
       - name: actor_id
         data_type: string
         description: "The xAPI actor identifier"
+      - name: emission_time
+        data_type: datetime
+        description: "The time the event was emitted"
       - name: state
         data_type: string
         description: "The most recent state of the learner's grade"
@@ -137,3 +109,39 @@ models:
       - name: scaled_score
         data_type: float64
         description: "A ratio between 0 and 1, inclusive, of the learner's grade"
+
+  - name: fact_student_status
+    description: "One record per learner per course for the most recent grade and enrollment status"
+    columns:
+      - name: org
+        data_type: string
+        description: "The organization that the course belongs to"
+      - name: course_key
+        data_type: string
+        description: "The course key for the course"
+      - name: actor_id
+        data_type: string
+        description: "The xAPI actor identifier"
+      - name: course_name
+        data_type: string
+        description: "The name of the course"
+      - name: course_run
+        data_type: string
+        description: "The course run for the course"
+      - name: state
+        data_type: string
+        description: "The most recent approving state for the learner"
+      - name: enrollment_status
+        description: "Whether a learner is actively enrolled in a course"
+        tests:
+          - accepted_values:
+              values: ["registered", "unregistered"]
+      - name: emission_time
+        data_type: datetime
+        description: "The time the event was emitted"
+      - name: course_grade
+        data_type: float64
+        description: "The most recent grade for the learner"
+      - name: grade_bucket
+        data_type: string
+        description: "A displayable value of grades sorted into 10% buckets. Useful for grouping grades together to show high-level learner performance"

--- a/models/grading/schema.yml
+++ b/models/grading/schema.yml
@@ -136,9 +136,6 @@ models:
         tests:
           - accepted_values:
               values: ["registered", "unregistered"]
-      - name: emission_time
-        data_type: datetime
-        description: "The time the event was emitted"
       - name: course_grade
         data_type: float64
         description: "The most recent grade for the learner"

--- a/models/grading/schema.yml
+++ b/models/grading/schema.yml
@@ -53,9 +53,6 @@ models:
       - name: course_key
         data_type: string
         description: "The course key for the course"
-      - name: course_run
-        data_type: string
-        description: "The course run"
       - name: actor_id
         data_type: string
         description: "The xAPI actor identifier"
@@ -126,9 +123,6 @@ models:
       - name: course_key
         data_type: string
         description: "The course key for the course"
-      - name: course_run
-        data_type: string
-        description: "The course run"
       - name: actor_id
         data_type: string
         description: "The xAPI actor identifier"

--- a/models/grading/schema.yml
+++ b/models/grading/schema.yml
@@ -53,6 +53,9 @@ models:
       - name: course_key
         data_type: string
         description: "The course key for the course"
+      - name: course_run
+        data_type: string
+        description: "The course run"
       - name: actor_id
         data_type: string
         description: "The xAPI actor identifier"
@@ -79,9 +82,9 @@ models:
       - name: emission_time
         data_type: datetime
         description: "The time the event was emitted"
-      - name: state
+      - name: approving_state
         data_type: string
-        description: "The most recent state of the learner's grade"
+        description: "The most recent approving_state of the learner's grade"
         tests:
           - accepted_values:
               values: ["passed", "failed"]

--- a/models/grading/schema.yml
+++ b/models/grading/schema.yml
@@ -59,6 +59,10 @@ models:
       - name: course_grade
         data_type: float64
         description: "The most recent grade for the learner"
+      - name: emission_time
+        data_type: datetime
+        description: "The time the event was emitted"
+
 
   - name: fact_learner_course_status
     description: "One record per learner per course for the most recent approving status"

--- a/models/navigation/schema.yml
+++ b/models/navigation/schema.yml
@@ -114,9 +114,10 @@ models:
         description: "The organization that the course belongs to"
       - name: course_key
         data_type: string
+        description: "The course identifier"
       - name: course_run
         data_type: string
-        description: "The course identifier"
+        description: "The course run for the course"
       - name: course_run
         data_type: string
         description: "The course run for the course"

--- a/models/navigation/schema.yml
+++ b/models/navigation/schema.yml
@@ -80,10 +80,13 @@ models:
     columns:
       - name: emission_date
         data_type: date
+        description: "The date the event was emitted"
       - name: org
         data_type: string
+        description: "The organization that the course belongs to"
       - name: course_key
         data_type: string
+        description: "The course identifier"
       - name: rollup_name
         data_type: string
         description: "The level at which page views are counted"
@@ -92,8 +95,10 @@ models:
               values: ["section", "subsection"]
       - name: block_name
         data_type: string
+        description: "The name of the section or subsection"
       - name: actor_id
         data_type: string
+        description: "The xAPI actor identifier"
       - name: total_views
         data_type: uint64
         description: "The total number of times a learner viewed pages in this section or subsection on a given day"
@@ -103,21 +108,52 @@ models:
     columns:
       - name: visited_on
         data_type: date
+        description: "The date the page was visited"
       - name: org
         data_type: string
+        description: "The organization that the course belongs to"
       - name: course_key
         data_type: string
       - name: course_run
         data_type: string
+        description: "The course identifier"
       - name: section_with_name
         data_type: string
+        description: "The name of the section"
       - name: subsection_with_name
         data_type: string
+        description: "The name of the subsection"
       - name: page_count
         data_type: uint64
         description: "The number of pages in the associated subsection"
       - name: actor_id
         data_type: string
+        description: "The xAPI actor identifier"
       - name: block_id
         data_type: string
         description: "The ID of the specific page visited"
+
+  - name: int_pages_per_subsection
+    description: ""
+    columns:
+      - name: org
+        data_type: string
+        description: The organization that the course belongs to
+      - name: course_key
+        data_type: string
+        description: The course identifier
+      - name: section_number
+        data_type: string
+        description: The section number
+      - name: section_with_name
+        data_type: string
+        description: The section number and name
+      - name: subsection_number
+        data_type: string
+        description: The subsection number
+      - name: subsection_with_name
+        data_type: string
+        description: The subsection number and name
+      - name: page_count
+        data_type: uint64
+        description: The number of pages in the associated subsection

--- a/models/navigation/schema.yml
+++ b/models/navigation/schema.yml
@@ -117,6 +117,9 @@ models:
       - name: course_run
         data_type: string
         description: "The course identifier"
+      - name: course_run
+        data_type: string
+        description: "The course run for the course"
       - name: section_with_name
         data_type: string
         description: "The name of the section"
@@ -134,7 +137,7 @@ models:
         description: "The ID of the specific page visited"
 
   - name: int_pages_per_subsection
-    description: ""
+    description: "A view for analyzing the number of pages in each subsection"
     columns:
       - name: org
         data_type: string

--- a/models/video/fact_video_plays.sql
+++ b/models/video/fact_video_plays.sql
@@ -7,6 +7,8 @@ with
             emission_time,
             org,
             course_key,
+            video_duration,
+            video_position,
             splitByString('/xblock/', object_id)[-1] as video_id,
             actor_id
         from {{ ref("video_playback_events") }}
@@ -22,6 +24,9 @@ select
     plays.video_id as video_id,
     blocks.block_name as video_name,
     blocks.display_name_with_location as video_name_with_location,
+    video_position,
+    video_duration,
+    {{ get_bucket("video_position/video_duration") }} as visualization_bucket,
     plays.actor_id as actor_id
 from plays
 join

--- a/models/video/schema.yml
+++ b/models/video/schema.yml
@@ -31,6 +31,15 @@ models:
       - name: actor_id
         data_type: String
         description: "The xAPI actor identifier"
+      - name: video_duration
+        data_type: Int64
+        description: "The duration of the video in seconds"
+      - name: video_position
+        data_type: Int64
+        description: "The seconds into the video where the play event occurred"
+      - name: visualization_bucket
+        data_type: String
+        description: "The percentile bucket for the video play event"
 
   - name: fact_transcript_usage
     description: "One record for each time a transcript or closed caption was enabled"
@@ -92,7 +101,7 @@ models:
         description: "The position in the video where the event occurred"
       - name: video_duration
         data_type: int64
-        description: "The duration of the video"
+        description: "The duration of the video in seconds"
 
   - name: video_transcript_events
     description: "Events related to video transcripts"


### PR DESCRIPTION
### Description

This PR creates an MV for the latest course enrollment status for a learner and renames the `fact_grade_status` to `fact_learner_status` with information of the current grade, current approving status and current enrollment status.

It also updates the `fact_video_plays` model to include video duration and visualization progress.