### PR TITLE
feat: add models for video engagement dropoff (FC-0051)

### DIFF
--- a/macros/items_per_subsection.sql
+++ b/macros/items_per_subsection.sql
@@ -1,0 +1,40 @@
+{% macro items_per_subsection(block_pattern) %}
+    with
+        items_per_subsection as (
+            select
+                org,
+                course_key,
+                section_number,
+                subsection_number,
+                count(*) as item_count
+            from {{ ref("dim_course_blocks") }}
+            where block_id like '{{ block_pattern }}'
+            group by org, course_key, section_number, subsection_number
+        )
+
+    select
+        ips.org as org,
+        ips.course_key as course_key,
+        ips.section_number as section_number,
+        section_blocks.display_name_with_location as section_with_name,
+        ips.subsection_number as subsection_number,
+        subsection_blocks.display_name_with_location as subsection_with_name,
+        ips.item_count as item_count
+    from items_per_subsection ips
+    left join
+        {{ ref("dim_course_blocks") }} section_blocks
+        on (
+            ips.section_number = section_blocks.hierarchy_location
+            and ips.org = section_blocks.org
+            and ips.course_key = section_blocks.course_key
+            and section_blocks.block_id like '%@chapter+block@%'
+        )
+    left join
+        {{ ref("dim_course_blocks") }} subsection_blocks
+        on (
+            ips.subsection_number = subsection_blocks.hierarchy_location
+            and ips.org = subsection_blocks.org
+            and ips.course_key = subsection_blocks.course_key
+            and subsection_blocks.block_id like '%@sequential+block@%'
+        )
+{% endmacro %}

--- a/macros/items_per_subsection.sql
+++ b/macros/items_per_subsection.sql
@@ -6,10 +6,11 @@
                 course_key,
                 section_number,
                 subsection_number,
+                graded,
                 count(*) as item_count
             from {{ ref("dim_course_blocks") }}
             where block_id like '{{ block_pattern }}'
-            group by org, course_key, section_number, subsection_number
+            group by org, course_key, section_number, subsection_number, graded
         )
 
     select
@@ -19,6 +20,7 @@
         section_blocks.display_name_with_location as section_with_name,
         ips.subsection_number as subsection_number,
         subsection_blocks.display_name_with_location as subsection_with_name,
+        ips.graded as graded,
         ips.item_count as item_count
     from items_per_subsection ips
     left join

--- a/models/video/fact_video_engagement.sql
+++ b/models/video/fact_video_engagement.sql
@@ -1,0 +1,32 @@
+with
+    viewed_subsection_videos as (
+        select distinct
+            date(emission_time) as viewed_on,
+            org,
+            course_key,
+            {{ section_from_display("video_name_with_location") }} as section_number,
+            {{ subsection_from_display("video_name_with_location") }}
+            as subsection_number,
+            actor_id,
+            video_id
+        from {{ ref("fact_video_plays") }}
+    )
+
+select
+    views.viewed_on,
+    views.org,
+    views.course_key,
+    videos.section_with_name,
+    videos.subsection_with_name,
+    videos.item_count,
+    views.actor_id,
+    views.video_id
+from viewed_subsection_videos views
+join
+    {{ ref("int_videos_per_subsection") }} videos
+    on (
+        views.org = videos.org
+        and views.course_key = videos.course_key
+        and views.section_number = videos.section_number
+        and views.subsection_number = videos.subsection_number
+    )

--- a/models/video/fact_video_engagement.sql
+++ b/models/video/fact_video_engagement.sql
@@ -7,6 +7,7 @@ with
             {{ section_from_display("video_name_with_location") }} as section_number,
             {{ subsection_from_display("video_name_with_location") }}
             as subsection_number,
+            graded,
             actor_id,
             video_id
         from {{ ref("fact_video_plays") }}
@@ -20,7 +21,8 @@ select
     videos.subsection_with_name,
     videos.item_count,
     views.actor_id,
-    views.video_id
+    views.video_id,
+    views.graded
 from viewed_subsection_videos views
 join
     {{ ref("int_videos_per_subsection") }} videos

--- a/models/video/fact_video_plays.sql
+++ b/models/video/fact_video_plays.sql
@@ -24,6 +24,7 @@ select
     plays.video_id as video_id,
     blocks.block_name as video_name,
     blocks.display_name_with_location as video_name_with_location,
+    blocks.graded as graded,
     video_position,
     video_duration,
     {{ get_bucket("video_position/video_duration") }} as visualization_bucket,

--- a/models/video/int_videos_per_subsection.sql
+++ b/models/video/int_videos_per_subsection.sql
@@ -1,0 +1,1 @@
+select * from ({{ items_per_subsection("%@video+block@%") }})

--- a/models/video/schema.yml
+++ b/models/video/schema.yml
@@ -127,3 +127,42 @@ models:
       - name: cc_enabled
         data_type: uint8
         description: "Whether closed captions were enabled"
+
+  - name: int_videos_per_subsection
+    columns:
+      - name: org
+        data_type: string
+      - name: course_key
+        data_type: string
+      - name: section_number
+        data_type: string
+        description: "The location of this section in the course, represented as section:0:0"
+      - name: section_with_name
+        data_type: string
+      - name: subsection_number
+        data_type: string
+        description: "The location of this subsection in the course, represented as section:subsection:0"
+      - name: subsection_with_name
+        data_type: string
+      - name: item_count
+        data_type: uint64
+
+  - name: fact_video_engagement
+    description: ""
+    columns:
+      - name: viewed_on
+        data_type: date
+      - name: org
+        data_type: string
+      - name: course_key
+        data_type: string
+      - name: section_with_name
+        data_type: string
+      - name: subsection_with_name
+        data_type: string
+      - name: item_count
+        data_type: uint64
+      - name: actor_id
+        data_type: string
+      - name: video_id
+        data_type: string

--- a/models/video/schema.yml
+++ b/models/video/schema.yml
@@ -129,40 +129,54 @@ models:
         description: "Whether closed captions were enabled"
 
   - name: int_videos_per_subsection
+    description: "A dimension table with the number of videos per subsection"
     columns:
       - name: org
         data_type: string
+        description: "The organization that the course belongs to"
       - name: course_key
         data_type: string
+        description: "The course key for the course"
       - name: section_number
         data_type: string
         description: "The location of this section in the course, represented as section:0:0"
       - name: section_with_name
         data_type: string
+        description: "The name of the section this subsection belongs to, with section_number prepended"
       - name: subsection_number
         data_type: string
         description: "The location of this subsection in the course, represented as section:subsection:0"
       - name: subsection_with_name
         data_type: string
+        description: "The name of the subsection, with section_number prepended"
       - name: item_count
         data_type: uint64
+        description: "The number of videos in this subsection"
 
   - name: fact_video_engagement
-    description: ""
+    description: "A dataset with one record representing a video viewed by a learner and the section and subsection that video belongs to"
     columns:
       - name: viewed_on
         data_type: date
+        description: "The date on which the video was viewed"
       - name: org
         data_type: string
+        description: "The organization that the video belongs to"
       - name: course_key
         data_type: string
+        description: "The course key for the course"
       - name: section_with_name
         data_type: string
+        description: "The name of the section this subsection belongs to, with section_number prepended"
       - name: subsection_with_name
         data_type: string
+        description: "The name of the subsection, with section_number prepended"
       - name: item_count
         data_type: uint64
+        description: "The number of videos in this subsection"
       - name: actor_id
         data_type: string
+        description: "The xAPI actor identifier"
       - name: video_id
         data_type: string
+        description: "The xAPI object identifier"

--- a/models/video/schema.yml
+++ b/models/video/schema.yml
@@ -28,6 +28,9 @@ models:
       - name: video_name_with_location
         data_type: String
         description: "The name of the video with the section and subsection"
+      - name: graded
+        data_type: Boolean
+        description: "Whether the block is graded"
       - name: actor_id
         data_type: String
         description: "The xAPI actor identifier"
@@ -149,6 +152,9 @@ models:
       - name: subsection_with_name
         data_type: string
         description: "The name of the subsection, with section_number prepended"
+      - name: graded
+        data_type: Boolean
+        description: "Whether the block is graded"
       - name: item_count
         data_type: uint64
         description: "The number of videos in this subsection"
@@ -180,3 +186,6 @@ models:
       - name: video_id
         data_type: string
         description: "The xAPI object identifier"
+      - name: graded
+        data_type: Boolean
+        description: "Whether the block is graded"


### PR DESCRIPTION
This adds one user-facing model (`fact_video_engagement`) and one internal model (`int_videos_per_subsection`) in order to support a chart that displays how many learners engaged with videos within a specific section or subsection. The macro `items_per_subsection` is meant to make it easier to create similar intermediate models for other item types (like problems or pages).