### PR TITLE
feat: add models for problem engagement (FC-0051)

### DIFF
--- a/models/problems/fact_problem_engagement.sql
+++ b/models/problems/fact_problem_engagement.sql
@@ -1,0 +1,36 @@
+with
+    attempted_subsection_problems as (
+        select distinct
+            date(emission_time) as attempted_on,
+            org,
+            course_key,
+            course_run,
+            {{ section_from_display("problem_name_with_location") }} as section_number,
+            {{ subsection_from_display("problem_name_with_location") }}
+            as subsection_number,
+            graded,
+            actor_id,
+            problem_id
+        from {{ ref("fact_problem_responses") }}
+    )
+
+select
+    attempts.attempted_on,
+    attempts.org,
+    attempts.course_key,
+    attempts.course_run,
+    problems.section_with_name,
+    problems.subsection_with_name,
+    problems.item_count,
+    attempts.actor_id,
+    attempts.problem_id,
+    attempts.graded
+from attempted_subsection_problems attempts
+join
+    {{ ref("int_problems_per_subsection") }} problems
+    on (
+        attempts.org = problems.org
+        and attempts.course_key = problems.course_key
+        and attempts.section_number = problems.section_number
+        and attempts.subsection_number = problems.subsection_number
+    )

--- a/models/problems/fact_problem_responses.sql
+++ b/models/problems/fact_problem_responses.sql
@@ -22,6 +22,7 @@ select
     responses.problem_id as problem_id,
     blocks.block_name as problem_name,
     blocks.display_name_with_location as problem_name_with_location,
+    blocks.graded as graded,
     responses.actor_id as actor_id,
     responses.responses as responses,
     responses.success as success,
@@ -47,4 +48,5 @@ group by
     actor_id,
     responses,
     success,
-    attempts
+    attempts,
+    graded

--- a/models/problems/int_problems_per_subsection.sql
+++ b/models/problems/int_problems_per_subsection.sql
@@ -1,0 +1,1 @@
+select * from ({{ items_per_subsection("%@problem+block@%") }})

--- a/models/problems/schema.yml
+++ b/models/problems/schema.yml
@@ -198,3 +198,65 @@ models:
       - name: attempts
         data_type: int16
         description: "Number indicating which attempt this was"
+
+  - name: int_problems_per_subsection
+    description: "A dimension table with the number of problems per subsection"
+    columns:
+      - name: org
+        data_type: string
+        description: "The organization that the course belongs to"
+      - name: course_key
+        data_type: string
+        description: "The course key for the course"
+      - name: section_number
+        data_type: string
+        description: "The location of this section in the course, represented as section:0:0"
+      - name: section_with_name
+        data_type: string
+        description: "The name of the section this subsection belongs to, with section_number prepended"
+      - name: subsection_number
+        data_type: string
+        description: "The location of this subsection in the course, represented as section:subsection:0"
+      - name: subsection_with_name
+        data_type: string
+        description: "The name of the subsection, with section_number prepended"
+      - name: graded
+        data_type: bool
+        description: "Whether this subsection block is graded"
+      - name: item_count
+        data_type: uint64
+        description: "The number of problems in this subsection"
+
+  - name: fact_problem_engagement
+    description: "A dataset with one record representing a problem attempted by a learner and the section and subsection that problem belongs to"
+    columns:
+      - name: attempted_on
+        data_type: date
+        description: "The date on which the problem was attempted"
+      - name: org
+        data_type: string
+        description: "The organization that the problem belongs to"
+      - name: course_key
+        data_type: string
+        description: "The course key for the course"
+      - name: course_run
+        data_type: string
+        description: "The course run for the course"
+      - name: section_with_name
+        data_type: string
+        description: "The name of the section this subsection belongs to, with section_number prepended"
+      - name: subsection_with_name
+        data_type: string
+        description: "The name of the subsection, with section_number prepended"
+      - name: item_count
+        data_type: uint64
+        description: "The number of problems in this subsection"
+      - name: actor_id
+        data_type: string
+        description: "The xAPI actor identifier"
+      - name: problem_id
+        data_type: string
+        description: "The xAPI object identifier"
+      - name: graded
+        data_type: bool
+        description: "Whether the block is graded"


### PR DESCRIPTION
Similar to #61, this adds models for tracking problem engagement per section and subsection. The primary model is `fact_problem_engagement`, which relies on an intermediate model named `int_problems_per_subsection`.