### PR TITLE
feat: add section names to problem dataset (FC-0051)

### DIFF
--- a/models/problems/fact_problem_responses.sql
+++ b/models/problems/fact_problem_responses.sql
@@ -9,7 +9,8 @@ with
             actor_id,
             responses,
             success,
-            attempts
+            attempts,
+            interaction_type
         from {{ ref("problem_events") }}
         where verb_id = 'https://w3id.org/xapi/acrossx/verbs/evaluated'
     )
@@ -28,7 +29,8 @@ select
     responses.actor_id as actor_id,
     responses.responses as responses,
     responses.success as success,
-    responses.attempts as attempts
+    responses.attempts as attempts,
+    responses.interaction_type as interaction_type
 from responses
 join
     {{ ref("dim_course_blocks") }} blocks
@@ -52,4 +54,5 @@ group by
     responses,
     success,
     attempts,
-    graded
+    graded,
+    interaction_type

--- a/models/problems/fact_problem_responses_extended.sql
+++ b/models/problems/fact_problem_responses_extended.sql
@@ -1,0 +1,33 @@
+with problem_results as (
+    select *,
+    {{ section_from_display("problem_name_with_location") }} as section_number,
+            {{ subsection_from_display("problem_name_with_location") }}
+            as subsection_number
+    from {{ ref("int_problem_results") }}
+)
+select
+    results.emission_time as emission_time,
+    results.org as org,
+    results.course_key as course_key,
+    results.course_name as course_name,
+    results.course_run as course_run,
+    problems.section_with_name as section_with_name,
+    problems.subsection_with_name as subsection_with_name,
+    results.problem_id as problem_id,
+    results.problem_name as problem_name,
+    results.problem_name_with_location as problem_name_with_location,
+    results.problem_link as problem_link,
+    results.actor_id as actor_id,
+    results.responses as responses,
+    results.success as success,
+    results.attempts as attempts,
+    results.graded as graded,
+    results.interaction_type as interaction_type
+from problem_results results
+join {{ ref("int_problems_per_subsection") }} problems
+on (
+        results.org = problems.org
+        and results.course_key = problems.course_key
+        and results.section_number = problems.section_number
+        and results.subsection_number = problems.subsection_number
+    )

--- a/models/problems/fact_problem_responses_extended.sql
+++ b/models/problems/fact_problem_responses_extended.sql
@@ -1,10 +1,12 @@
-with problem_results as (
-    select *,
-    {{ section_from_display("problem_name_with_location") }} as section_number,
+with
+    problem_results as (
+        select
+            *,
+            {{ section_from_display("problem_name_with_location") }} as section_number,
             {{ subsection_from_display("problem_name_with_location") }}
             as subsection_number
-    from {{ ref("int_problem_results") }}
-)
+        from {{ ref("int_problem_results") }}
+    )
 select
     results.emission_time as emission_time,
     results.org as org,
@@ -24,8 +26,9 @@ select
     results.graded as graded,
     results.interaction_type as interaction_type
 from problem_results results
-join {{ ref("int_problems_per_subsection") }} problems
-on (
+join
+    {{ ref("int_problems_per_subsection") }} problems
+    on (
         results.org = problems.org
         and results.course_key = problems.course_key
         and results.section_number = problems.section_number

--- a/models/problems/int_problem_results.sql
+++ b/models/problems/int_problem_results.sql
@@ -52,6 +52,8 @@ select
     actor_id,
     responses,
     success,
-    attempts
+    attempts,
+    graded,
+    interaction_type
 from {{ ref("fact_problem_responses") }} problem_responses
 join responses using (org, course_key, problem_id, actor_id, emission_time)

--- a/models/problems/schema.yml
+++ b/models/problems/schema.yml
@@ -272,3 +272,58 @@ models:
       - name: graded
         data_type: bool
         description: "Whether the block is graded"
+
+  - name: fact_problem_responses_extended
+    description: "int_problem_results with section and subsection names"
+    columns:
+      - name: emission_time
+        data_type: datetime
+        description: "The time the event was emitted"
+      - name: org
+        data_type: string
+        description: "The organization that the course belongs to"
+      - name: course_key
+        data_type: string
+        description: "The course key for the course"
+      - name: course_name
+        data_type: string
+        description: "The name of the course"
+      - name: course_run
+        data_type: string
+        description: "The course run for the course"
+      - name: section_with_name
+        data_type: string
+        description: "The name of the section this subsection belongs to, with section_number prepended"
+      - name: subsection_with_name
+        data_type: string
+        description: "The name of the subsection, with section_number prepended"
+      - name: problem_id
+        data_type: string
+        description: "The problem's unique identifier"
+      - name: problem_name
+        data_type: string
+        description: "The problem's name"
+      - name: problem_name_with_location
+        data_type: string
+        description: "The problem's display name with section, subsection, and unit prepended to the name. This provides additional context when looking at problem names and can help data consumers understand which problem they are analyzing"
+      - name: problem_link
+        data_type: String
+        description: "An anchor tag with a link to the problem"
+      - name: actor_id
+        data_type: string
+        description: "The xAPI actor identifier"
+      - name: responses
+        data_type: string
+        description: "The responses for this submission. If a problem has multiple parts, values for all parts will be in this field"
+      - name: success
+        data_type: bool
+        description: "Boolean indicating whether the responses were correct"
+      - name: attempts
+        data_type: int16
+        description: "Number indicating which attempt this was"
+      - name: graded
+        data_type: bool
+        description: "Whether this subsection block is graded"
+      - name: interaction_type
+        data_type: string
+        description: "The type of interaction"

--- a/models/problems/schema.yml
+++ b/models/problems/schema.yml
@@ -93,6 +93,9 @@ models:
       - name: graded
         data_type: bool
         description: "Boolean indicating this block is graded"
+      - name: interaction_type
+        data_type: string
+        description: "The type of interaction - e.g. multiple choice"
 
   - name: int_problem_hints
     description: "Internal table for problem hints"
@@ -170,6 +173,12 @@ models:
       - name: attempts
         data_type: int16
         description: "Number indicating which attempt this was"
+      - name: graded
+        data_type: bool
+        description: "Boolean indicating this block is graded"
+      - name: interaction_type
+        data_type: string
+        description: "The type of interaction - e.g. multiple choice"
 
   - name: problem_events
     description: "Problem events"


### PR DESCRIPTION
This change introduces a new model, `fact_problem_responses_extended`, which contains section and subsection names alongside problem results. This also includes `interaction_type`, which specifies the type of answer the problem accepts (e.g. multiple choice)