### PR TITLE
build: CI fixes, move coverage to separate workflow

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,7 +1,6 @@
-# Build documentation for dbt-aspects on every PR to main.
-# Deploy documentation to gh-pages branch on every push to main.
+# Check documentation coverage
 
-name: Build documentation
+name: dbt Docs Coverage
 
 on:
   push:
@@ -20,9 +19,7 @@ env:
 
 jobs:
   build:
-    # Forks will never have permissions to do this, so skip this for those
-    if: github.event.pull_request.head.repo.full_name == github.repository
-    name: Deploy dbt docs to github pages
+    name: Build docs and check coverage
     runs-on: ubuntu-latest
     permissions:
       contents: "read"
@@ -30,8 +27,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-        with:
-          token: ${{ secrets.SEMANTIC_RELEASE_GITHUB_TOKEN }}
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
@@ -48,14 +43,8 @@ jobs:
           tutor local start -d
           tutor local do init
           tutor local do load-xapi-test-data
-      - name: Build docs
+      - name: Check docs coverage
         run: |
           dbt run
           dbt docs generate
-      - name: Deploy
-        if: github.event_name == 'push'
-        uses: peaceiris/actions-gh-pages@v4
-        with:
-          github_token: ${{ secrets.SEMANTIC_RELEASE_GITHUB_TOKEN }}
-          publish_dir: ./target
-          commit_message: "docs: update docs for "
+          dbt-coverage compute doc --cov-fail-under 1.0

--- a/models/problems/schema.yml
+++ b/models/problems/schema.yml
@@ -87,6 +87,9 @@ models:
       - name: attempts
         description: "Number indicating which attempt this was"
         data_type: Int16
+      - name: graded
+        data_type: bool
+        description: "Boolean indicating this block is graded"
 
   - name: int_problem_hints
     description: "Internal table for problem hints"


### PR DESCRIPTION
This should allow us to still test for coverage from forks, but avoid trying to push docs from fork PRs since they will never have the right permissions for the secrets. Testing with a fork happened here, you can see that the docs build is skipped instead of erroring: https://github.com/openedx/aspects-dbt/pull/69