### PR TITLE
feat: add extended course block dimension table (FC-0051)

### DIFF
--- a/models/courses/dim_course_blocks_extended.sql
+++ b/models/courses/dim_course_blocks_extended.sql
@@ -1,0 +1,32 @@
+select
+    blocks.org as org,
+    blocks.course_key as course_key,
+    blocks.course_name as course_name,
+    blocks.course_run as course_run,
+    blocks.block_id as block_id,
+    blocks.block_name as block_name,
+    blocks.section_number as section_number,
+    blocks.subsection_number as subsection_number,
+    blocks.hierarchy_location as hierarchy_location,
+    blocks.display_name_with_location as display_name_with_location,
+    blocks.graded as graded,
+    blocks.block_type as block_type,
+    section_blocks.display_name_with_location as section_with_name,
+    subsection_blocks.display_name_with_location as subsection_with_name
+from {{ ref("dim_course_blocks") }} blocks
+left join
+    {{ ref("dim_course_blocks") }} section_blocks
+    on (
+        blocks.section_number = section_blocks.hierarchy_location
+        and blocks.org = section_blocks.org
+        and blocks.course_key = section_blocks.course_key
+        and section_blocks.block_id like '%@chapter+block@%'
+    )
+left join
+    {{ ref("dim_course_blocks") }} subsection_blocks
+    on (
+        blocks.subsection_number = subsection_blocks.hierarchy_location
+        and blocks.org = subsection_blocks.org
+        and blocks.course_key = subsection_blocks.course_key
+        and subsection_blocks.block_id like '%@sequential+block@%'
+    )

--- a/models/courses/schema.yml
+++ b/models/courses/schema.yml
@@ -2,7 +2,7 @@ version: 2
 
 models:
   - name: dim_course_blocks
-    description: "A denormalized table of course block information"
+    description: "A denormalized table of course block information. This should be preferred over dim_course_blocks_extended when section and subsection names are not necessary to include in a model"
     columns:
       - name: org
         data_type: String
@@ -75,3 +75,49 @@ models:
       - name: org
         data_type: String
         description: "The organization that the course belongs to"
+
+  - name: dim_course_blocks_extended
+    description: "dim_course_blocks with section and subsection names joined into the data."
+    columns:
+      - name: org
+        data_type: String
+        description: "The organization that the course belongs to"
+      - name: course_key
+        data_type: String
+        description: "The course key for the course"
+      - name: course_name
+        data_type: String
+        description: "The name of the course"
+      - name: course_run
+        data_type: String
+        description: "The course run for the course"
+      - name: block_id
+        data_type: String
+        description: "The block's unique identifier"
+      - name: block_name
+        data_type: String
+        description: "The block's name"
+      - name: section_number
+        data_type: string
+        description: "The section this block belongs to, formatted as <section location>:0:0"
+      - name: subsection_number
+        data_type: string
+        description: "The subsection this block belongs to, formatted as <section location>:<subsection location>:0"
+      - name: hierarchy_location
+        data_type: string
+        description: "The full section:subsection:unit hierarchy in which this block belongs"
+      - name: display_name_with_location
+        data_type: String
+        description: "The block's display name with section, subsection, and unit prepended to the name. This provides additional context when looking at block names and can help data consumers understand which block they are analyzing"
+      - name: graded
+        data_type: Boolean
+        description: "Whether the block is graded"
+      - name: block_type
+        data_type: String
+        description: "The type of block. This can be a section, subsection, unit, or the block type"
+      - name: section_with_name
+        data_type: string
+        description: "The name of the section this block belongs to, with section_number prepended"
+      - name: subsection_with_name
+        data_type: string
+        description: "The name of the section this subsection belongs to, with subsection_number prepended"


### PR DESCRIPTION
This change introduces another dimension table, `dim_course_blocks_extended`, which includes the section and subsection names to which each block belongs. This is included as a separate model instead of adding onto `dim_course_blocks` so as to avoid any unnecessary joins when a model requires block metadata but does not need the extra information joined into `dim_course_blocks` by this new model.