### PR TITLE
feat: include section names in fact_video_plays (FC-0051)

### DIFF
--- a/models/video/fact_video_plays.sql
+++ b/models/video/fact_video_plays.sql
@@ -27,16 +27,18 @@ select
     blocks.display_name_with_location as video_name_with_location,
     {{ a_tag("plays.object_id", "blocks.block_name") }} as video_link,
     blocks.graded as graded,
-    video_position,
-    video_duration,
+    plays.video_position as video_position,
+    plays.video_duration as video_duration,
     {{ get_bucket("video_position/video_duration") }} as visualization_bucket,
     plays.actor_id as actor_id,
     users.username as username,
     users.name as name,
-    users.email as email
+    users.email as email,
+    blocks.section_with_name as section_with_name,
+    blocks.subsection_with_name as subsection_with_name
 from plays
 join
-    {{ ref("dim_course_blocks") }} blocks
+    {{ ref("dim_course_blocks_extended") }} blocks
     on (plays.course_key = blocks.course_key and plays.video_id = blocks.block_id)
 left outer join
     {{ ref("dim_user_pii") }} users on toUUID(actor_id) = users.external_user_id

--- a/models/video/schema.yml
+++ b/models/video/schema.yml
@@ -55,6 +55,12 @@ models:
       - name: email
         data_type: String
         description: "The email address of the learner"
+      - name: section_with_name
+        data_type: string
+        description: "The name of the section this video belongs to, with section_number prepended"
+      - name: subsection_with_name
+        data_type: string
+        description: "The name of the subsection this video belongs to, with subsection_number prepended"
 
   - name: fact_transcript_usage
     description: "One record for each time a transcript or closed caption was enabled"


### PR DESCRIPTION
This change adds `section_with_name` and `subsection_with_name` to `fact_video_plays`. This is to be able to provide additional context to dashboard viewers about which videos are included in which sections or subsections.