### PR TITLE
fix: add course_run to video engagement dataset (FC-0051)

### DIFF
--- a/models/video/fact_video_engagement.sql
+++ b/models/video/fact_video_engagement.sql
@@ -4,6 +4,7 @@ with
             date(emission_time) as viewed_on,
             org,
             course_key,
+            course_run,
             {{ section_from_display("video_name_with_location") }} as section_number,
             {{ subsection_from_display("video_name_with_location") }}
             as subsection_number,
@@ -20,6 +21,7 @@ select
     views.viewed_on,
     views.org,
     views.course_key,
+    views.course_run,
     videos.section_with_name,
     videos.subsection_with_name,
     videos.item_count,

--- a/models/video/schema.yml
+++ b/models/video/schema.yml
@@ -198,6 +198,9 @@ models:
       - name: course_key
         data_type: string
         description: "The course key for the course"
+      - name: course_run
+        data_type: String
+        description: "The course run for the course"
       - name: section_with_name
         data_type: string
         description: "The name of the section this subsection belongs to, with section_number prepended"


### PR DESCRIPTION
This change adds `course_run` to `fact_video_engagement`, which enables filtering based on course_run to any charts that rely on `fact_video_engagement`.