### PR TITLE
feat: add enrollment timestamp to at-risk learners (FC-0051)

### DIFF
--- a/models/grading/fact_student_status.sql
+++ b/models/grading/fact_student_status.sql
@@ -11,7 +11,8 @@ select
     {{ get_bucket("course_grade") }} as grade_bucket,
     users.username as username,
     users.name as name,
-    users.email as email
+    users.email as email,
+    fes.emission_time as enrolled_at
 from {{ ref("fact_enrollment_status") }} fes
 left join
     {{ ref("fact_learner_course_status") }} lg

--- a/models/grading/schema.yml
+++ b/models/grading/schema.yml
@@ -169,4 +169,4 @@ models:
         description: "The email address of the learner"
       - name: enrolled_at
         data_type: DateTime
-        description: "The timestamp, to the second, of when the learner enrolled in the course"
+        description: "The timestamp, to the second, of the most recent enrollment action for this learner and course."

--- a/models/grading/schema.yml
+++ b/models/grading/schema.yml
@@ -167,3 +167,6 @@ models:
       - name: email
         data_type: String
         description: "The email address of the learner"
+      - name: enrolled_at
+        data_type: DateTime
+        description: "The timestamp, to the second, of when the learner enrolled in the course"

--- a/models/users/dim_at_risk_learners.sql
+++ b/models/users/dim_at_risk_learners.sql
@@ -16,6 +16,7 @@ select
     learners.email as email,
     learners.enrollment_mode as enrollment_mode,
     learners.course_grade as course_grade,
+    learners.enrolled_at as enrolled_at,
     page_visits.last_visited as last_visited
 from {{ ref("fact_student_status") }} learners
 join page_visits using (org, course_key, actor_id)

--- a/models/users/schema.yml
+++ b/models/users/schema.yml
@@ -72,7 +72,7 @@ models:
         description: "The most recent grade for the learner"
       - name: enrolled_at
         data_type: DateTime
-        description: "The timestamp, to the second, of when the learner enrolled in the course"
+        description: "The timestamp, to the second, of the most recent enrollment action for this learner and course."
       - name: last_visited
         data_type: datetime
         description: "The last time the learner visited a page for this course"

--- a/models/users/schema.yml
+++ b/models/users/schema.yml
@@ -70,6 +70,9 @@ models:
       - name: course_grade
         data_type: float64
         description: "The most recent grade for the learner"
+      - name: enrolled_at
+        data_type: DateTime
+        description: "The timestamp, to the second, of when the learner enrolled in the course"
       - name: last_visited
         data_type: datetime
         description: "The last time the learner visited a page for this course"


### PR DESCRIPTION
This change adds the timestamp of when a learner enrolled in a course to the `fact_student_status` model. This field is then used in `dim_at_risk_learners` to support displaying a distribution of when at-risk learners enrolled in the course.