### PR TITLE
feat: add grade bucket to dim_at_risk_learners (FC-0051)

### DIFF
--- a/models/users/dim_at_risk_learners.sql
+++ b/models/users/dim_at_risk_learners.sql
@@ -17,6 +17,7 @@ select
     learners.enrollment_mode as enrollment_mode,
     learners.course_grade as course_grade,
     learners.enrolled_at as enrolled_at,
+    learners.grade_bucket as grade_bucket,
     page_visits.last_visited as last_visited
 from {{ ref("fact_student_status") }} learners
 join page_visits using (org, course_key, actor_id)

--- a/models/users/schema.yml
+++ b/models/users/schema.yml
@@ -73,6 +73,9 @@ models:
       - name: enrolled_at
         data_type: DateTime
         description: "The timestamp, to the second, of the most recent enrollment action for this learner and course."
+      - name: grade_bucket
+        data_type: string
+        description: "A displayable value of grades sorted into 10% buckets. Useful for grouping grades together to show high-level learner performance"
       - name: last_visited
         data_type: datetime
         description: "The last time the learner visited a page for this course"


### PR DESCRIPTION
This change adds `grade_bucket` to the `dim_at_risk_learners` model, which can be used to display a breakdown of current course grades for at-risk learners.