### PR TITLE
fix: do not rejoin user PII information on fact_navigation_completion

### DIFF
--- a/models/navigation/fact_navigation_completion.sql
+++ b/models/navigation/fact_navigation_completion.sql
@@ -11,7 +11,10 @@ with
             {{ subsection_from_display("block_name_with_location") }}
             as subsection_number,
             actor_id,
-            block_id
+            block_id,
+            username,
+            name,
+            email
         from {{ ref("fact_navigation") }}
     )
 
@@ -27,9 +30,9 @@ select
     pages.item_count as page_count,
     visits.actor_id as actor_id,
     visits.block_id as block_id,
-    users.username as username,
-    users.name as name,
-    users.email as email
+    visits.username as username,
+    visits.name as name,
+    visits.email as email
 from visited_subsection_pages visits
 join
     {{ ref("int_pages_per_subsection") }} pages
@@ -39,5 +42,3 @@ join
         and visits.section_number = pages.section_number
         and visits.subsection_number = pages.subsection_number
     )
-left outer join
-    {{ ref("dim_user_pii") }} users on toUUID(actor_id) = users.external_user_id


### PR DESCRIPTION
### Description

This PR fixes an issue in which the join operation was applied twice on the user_pii dataset for the fact_navigation_completion report.