### PR TITLE
fix: use table instead of MV for section_video_engagement MV

### DIFF
--- a/models/video/section_video_engagement.sql
+++ b/models/video/section_video_engagement.sql
@@ -9,6 +9,20 @@
 }}
 
 with
+    plays as (
+        select
+            emission_time,
+            org,
+            course_key,
+            splitByString('/xblock/', object_id)[-1] as video_id,
+            actor_id,
+            blocks.display_name_with_location as video_name_with_location
+        from {{ ref("video_playback_events") }} plays
+        join
+            {{ ref("course_block_names") }} blocks
+            on (plays.course_key = blocks.course_key and video_id = blocks.location)
+        where verb_id = 'https://w3id.org/xapi/video/verbs/played'
+    ),
     viewed_subsection_videos as (
         select distinct
             date(emission_time) as viewed_on,
@@ -19,7 +33,7 @@ with
             as subsection_number,
             actor_id,
             video_id
-        from {{ ref("fact_video_plays") }}
+        from plays
     ),
     fact_video_engagement_per_subsection as (
         select

--- a/models/video/subsection_video_engagement.sql
+++ b/models/video/subsection_video_engagement.sql
@@ -9,6 +9,20 @@
 }}
 
 with
+    plays as (
+        select
+            emission_time,
+            org,
+            course_key,
+            splitByString('/xblock/', object_id)[-1] as video_id,
+            actor_id,
+            blocks.display_name_with_location as video_name_with_location
+        from {{ ref("video_playback_events") }} plays
+        join
+            {{ ref("course_block_names") }} blocks
+            on (plays.course_key = blocks.course_key and video_id = blocks.location)
+        where verb_id = 'https://w3id.org/xapi/video/verbs/played'
+    ),
     viewed_subsection_videos as (
         select distinct
             date(emission_time) as viewed_on,
@@ -19,7 +33,7 @@ with
             as subsection_number,
             actor_id,
             video_id
-        from {{ ref("fact_video_plays") }}
+        from plays
     ),
     fact_video_engagement_per_subsection as (
         select


### PR DESCRIPTION
### Description

This PR reduces the dependencies from the section/subsection_video_engagement MV, so that it doesn't get OOM killed on large datasets.

### Performance gains:
Before:
```
0 rows in set. Elapsed: 0.283 sec. Processed 11.21 thousand rows, 2.36 MB (39.64 thousand rows/s., 8.35 MB/s.)
Peak memory usage: 35.93 MiB
```
After:
```
0 rows in set. Elapsed: 0.062 sec. Processed 8.48 thousand rows, 1.97 MB (136.64 thousand rows/s., 31.79 MB/s.)
Peak memory usage: 12.89 MiB.
```