### PR TITLE
fix: improve memory usage and performance of course_block_names

### DIFF
--- a/models/courses/course_block_names.sql
+++ b/models/courses/course_block_names.sql
@@ -21,10 +21,5 @@
 }}
 
 select
-    location as location,
-    block_name,
-    course_key,
-    graded,
-    course_order,
-    display_name_with_location
-from {{ ref("most_recent_course_blocks") }} course_blocks
+    location, block_name, course_key, graded, course_order, display_name_with_location
+from {{ ref("most_recent_course_blocks") }}

--- a/models/courses/course_block_names.sql
+++ b/models/courses/course_block_names.sql
@@ -20,37 +20,25 @@
     )
 }}
 
-with
-    most_recent_course_blocks as (
-        select
-            location,
-            display_name,
-            toString(section)
-            || ':'
-            || toString(subsection)
-            || ':'
-            || toString(unit)
-            || ' - '
-            || display_name as display_name_with_location,
-            JSONExtractInt(xblock_data_json, 'section') as section,
-            JSONExtractInt(xblock_data_json, 'subsection') as subsection,
-            JSONExtractInt(xblock_data_json, 'unit') as unit,
-            JSONExtractBool(xblock_data_json, 'graded') as graded,
-            `order` as course_order,
-            course_key,
-            dump_id,
-            time_last_dumped,
-            row_number() over (
-                partition by location order by time_last_dumped desc
-            ) as rn
-        from {{ source("event_sink", "course_blocks") }}
-    )
 select
-    location,
+    course_blocks.location as location,
     display_name as block_name,
     course_key,
-    graded,
-    course_order,
-    display_name_with_location
-from most_recent_course_blocks
-where rn = 1
+    JSONExtractBool(xblock_data_json, 'graded') as graded,
+    order as course_order,
+    toString(JSONExtractInt(xblock_data_json, 'section'))
+    || ':'
+    || toString(JSONExtractInt(xblock_data_json, 'subsection'))
+    || ':'
+    || toString(JSONExtractInt(xblock_data_json, 'unit'))
+    || ' - '
+    || display_name as display_name_with_location
+from {{ source("event_sink", "course_blocks") }} course_blocks
+join
+    (
+        select location, max(time_last_dumped) as max_time_last_dumped
+        from {{ source("event_sink", "course_blocks") }}
+        group by location
+    ) latest_course_blocks
+    on course_blocks.location = latest_course_blocks.location
+    and course_blocks.time_last_dumped = latest_course_blocks.max_time_last_dumped

--- a/models/courses/course_block_names.sql
+++ b/models/courses/course_block_names.sql
@@ -21,24 +21,10 @@
 }}
 
 select
-    course_blocks.location as location,
+    location as location,
     display_name as block_name,
     course_key,
-    JSONExtractBool(xblock_data_json, 'graded') as graded,
+    graded,
     order as course_order,
-    toString(JSONExtractInt(xblock_data_json, 'section'))
-    || ':'
-    || toString(JSONExtractInt(xblock_data_json, 'subsection'))
-    || ':'
-    || toString(JSONExtractInt(xblock_data_json, 'unit'))
-    || ' - '
-    || display_name as display_name_with_location
-from {{ source("event_sink", "course_blocks") }} course_blocks
-join
-    (
-        select location, max(time_last_dumped) as max_time_last_dumped
-        from {{ source("event_sink", "course_blocks") }}
-        group by location
-    ) latest_course_blocks
-    on course_blocks.location = latest_course_blocks.location
-    and course_blocks.time_last_dumped = latest_course_blocks.max_time_last_dumped
+    display_name_with_location
+from {{ ref("most_recent_course_blocks") }} course_blocks

--- a/models/courses/course_block_names.sql
+++ b/models/courses/course_block_names.sql
@@ -25,6 +25,6 @@ select
     block_name,
     course_key,
     graded,
-    order as course_order,
+    course_order,
     display_name_with_location
 from {{ ref("most_recent_course_blocks") }} course_blocks

--- a/models/courses/course_block_names.sql
+++ b/models/courses/course_block_names.sql
@@ -22,7 +22,7 @@
 
 select
     location as location,
-    display_name as block_name,
+    block_name,
     course_key,
     graded,
     order as course_order,

--- a/models/courses/most_recent_course_blocks.sql
+++ b/models/courses/most_recent_course_blocks.sql
@@ -23,7 +23,7 @@ select
     JSONExtractInt(xblock_data_json, 'unit') as unit,
     JSONExtractBool(xblock_data_json, 'graded') as graded,
     course_key,
-    order,
+    order as course_order,
     dump_id,
     time_last_dumped
 from {{ source("event_sink", "course_blocks") }}

--- a/models/courses/most_recent_course_blocks.sql
+++ b/models/courses/most_recent_course_blocks.sql
@@ -1,6 +1,7 @@
 {{
     config(
         materialized="materialized_view",
+        schema=env_var("ASPECTS_EVENT_SINK_DATABASE", "event_sink"),
         engine=get_engine("ReplacingMergeTree()"),
         primary_key="(location)",
         order_by="(location)",

--- a/models/courses/most_recent_course_blocks.sql
+++ b/models/courses/most_recent_course_blocks.sql
@@ -1,0 +1,28 @@
+{{
+    config(
+        materialized="materialized_view",
+        engine=get_engine("ReplacingMergeTree()"),
+        primary_key="(location)",
+        order_by="(location)",
+        post_hook="OPTIMIZE TABLE {{ this }} {{ on_cluster() }} FINAL",
+    )
+}}
+
+select
+    location,
+    display_name as block_name,
+    toString(section)
+    || ':'
+    || toString(subsection)
+    || ':'
+    || toString(unit)
+    || ' - '
+    || display_name as display_name_with_location,
+    JSONExtractInt(xblock_data_json, 'section') as section,
+    JSONExtractInt(xblock_data_json, 'subsection') as subsection,
+    JSONExtractInt(xblock_data_json, 'unit') as unit,
+    JSONExtractBool(xblock_data_json, 'graded') as graded,
+    course_key,
+    dump_id,
+    time_last_dumped
+from {{ source("event_sink", "course_blocks") }}

--- a/models/courses/most_recent_course_blocks.sql
+++ b/models/courses/most_recent_course_blocks.sql
@@ -23,6 +23,7 @@ select
     JSONExtractInt(xblock_data_json, 'unit') as unit,
     JSONExtractBool(xblock_data_json, 'graded') as graded,
     course_key,
+    order,
     dump_id,
     time_last_dumped
 from {{ source("event_sink", "course_blocks") }}

--- a/models/courses/schema.yml
+++ b/models/courses/schema.yml
@@ -44,6 +44,43 @@ models:
         data_type: Int32
         description: "The sort order of this block in the course across all course blocks"
 
+  - name: most_recent_course_blocks
+    description: "A table with the most recent course blocks"
+    columns:
+      - name: location
+        data_type: String
+        description: "The location of the block"
+      - name: block_name
+        data_type: String
+        description: "The name of the block"
+      - name: display_name_with_location
+        data_type: String
+        description: "The block's display name with section, subsection, and unit prepended to the name."
+      - name: section
+        data_type: Int32
+        description: "The section number"
+      - name: subsection
+        data_type: Int32
+        description: "The subsection number"
+      - name: unit
+        data_type: Int32
+        description: "The unit number"
+      - name: graded
+        data_type: Boolean
+        description: "Whether the block is graded"
+      - name: course_key
+        data_type: String
+        description: "The location of the block"
+      - name: course_order
+        data_type: Int32
+        description: "The sort order of this block in the course across all course blocks"
+      - name: dump_id
+        data_type: String
+        description: "The UUID for the dump"
+      - name: time_last_dumped
+        data_type: String
+        description: "The time of the dump"
+
   - name: course_block_names
     description: "A table of course blocks with their names"
     columns:


### PR DESCRIPTION
### Description

This PR improves the memory usage of the course_block_names dictionary by changing a window function for a subquery.

### Performance

With 54.5 million records on `course_blocks`:

- Before:

```
DB::Exception: Memory limit (total) exceeded: would use 13.88 GiB (attempt to allocate chunk of 5014048 bytes), maximum: 13.83 GiB. OvercommitTracker decision: Query was selected to stop by OvercommitTracker.: (avg_value_size_hint = 188.5636613902271, avg_chars_size = 216.67639366827254, limit = 8192): (while reading column xblock_data_json): (while reading from part /var/lib/clickhouse/store/a70/a70916e8-45bc-45a0-8037-63f63365b414/all_17711_36212_166/ in table event_sink.course_blocks (a70916e8-45bc-45a0-8037-63f63365b414) located on disk default of type local, from mark 2537 with max_rows_to_read = 8192): While executing MergeTreeThread. Stack trace:
```

-After:

```
Query id: 48bdd86c-9488-4c4d-874b-f306136a2c4b

Ok.

0 rows in set. Elapsed: 10.133 sec. Processed 108.88 million rows, 29.31 GB (10.75 million rows/s., 2.89 GB/s.)
Peak memory usage: 586.75 MiB.
```