### PR TITLE
fix: remove event_sink schema

### DIFF
--- a/models/tags/most_recent_course_tags.sql
+++ b/models/tags/most_recent_course_tags.sql
@@ -27,5 +27,7 @@ with
     )
 select course_key, course_name, tag_id, value as tag, lineage, mrt.name as taxonomy_name
 from parsed_tags
-inner join {{ ref("most_recent_tags") }} mrot FINAL on mrot.id = tag_id
-inner join {{ ref("most_recent_taxonomies") }} mrt FINAL on mrt.id = mrot.taxonomy
+inner join {{ source("event_sink", "most_recent_tags") }} mrot FINAL on mrot.id = tag_id
+inner join
+    {{ source("event_sink", "most_recent_taxonomies") }} mrt FINAL
+    on mrt.id = mrot.taxonomy

--- a/models/tags/most_recent_course_tags.sql
+++ b/models/tags/most_recent_course_tags.sql
@@ -27,7 +27,5 @@ with
     )
 select course_key, course_name, tag_id, value as tag, lineage, mrt.name as taxonomy_name
 from parsed_tags
-inner join {{ source("event_sink", "most_recent_tags") }} mrot FINAL on mrot.id = tag_id
-inner join
-    {{ source("event_sink", "most_recent_taxonomies") }} mrt FINAL
-    on mrt.id = mrot.taxonomy
+inner join {{ ref("most_recent_tags") }} mrot FINAL on mrot.id = tag_id
+inner join {{ ref("most_recent_taxonomies") }} mrt FINAL on mrt.id = mrot.taxonomy

--- a/models/tags/most_recent_object_tags.sql
+++ b/models/tags/most_recent_object_tags.sql
@@ -1,7 +1,6 @@
 {{
     config(
         materialized="materialized_view",
-        schema=env_var("ASPECTS_EVENT_SINK_DATABASE", "event_sink"),
         engine=get_engine("ReplacingMergeTree()"),
         order_by="(id)",
         post_hook="OPTIMIZE TABLE {{ this }} {{ on_cluster() }} FINAL",

--- a/models/tags/most_recent_tags.sql
+++ b/models/tags/most_recent_tags.sql
@@ -1,7 +1,6 @@
 {{
     config(
         materialized="materialized_view",
-        schema=env_var("ASPECTS_EVENT_SINK_DATABASE", "event_sink"),
         engine=get_engine("ReplacingMergeTree()"),
         order_by="(id)",
         post_hook="OPTIMIZE TABLE {{ this }} {{ on_cluster() }} FINAL",

--- a/models/tags/most_recent_taxonomies.sql
+++ b/models/tags/most_recent_taxonomies.sql
@@ -1,7 +1,6 @@
 {{
     config(
         materialized="materialized_view",
-        schema=env_var("ASPECTS_EVENT_SINK_DATABASE", "event_sink"),
         engine=get_engine("ReplacingMergeTree()"),
         order_by="(id)",
         post_hook="OPTIMIZE TABLE {{ this }} {{ on_cluster() }} FINAL",


### PR DESCRIPTION
Materialized views that are not the original data source should not specify a schema so they are created in the 'reporting' schema