### PR TITLE
fix: use table instead of view for video engagement mv

### DIFF
--- a/models/video/section_video_engagement.sql
+++ b/models/video/section_video_engagement.sql
@@ -9,17 +9,46 @@
 }}
 
 with
+    plays as (
+        select
+            emission_time,
+            org,
+            course_key,
+            object_id,
+            video_duration,
+            video_position,
+            splitByString('/xblock/', object_id)[-1] as video_id,
+            actor_id
+        from {{ ref("video_playback_events") }}
+        where verb_id = 'https://w3id.org/xapi/video/verbs/played'
+    ),
+    fact_video_plays as (
+        select
+            plays.emission_time as emission_time,
+            plays.org as org,
+            plays.course_key as course_key,
+            plays.video_id as video_id,
+            blocks.section_number as section_number,
+            blocks.subsection_number as subsection_number,
+            plays.actor_id as actor_id
+        from plays
+        join
+            {{ ref("dim_course_blocks") }} blocks
+            on (
+                plays.course_key = blocks.course_key
+                and plays.video_id = blocks.block_id
+            )
+    ),
     viewed_subsection_videos as (
         select distinct
             date(emission_time) as viewed_on,
             org,
             course_key,
-            {{ section_from_display("video_name_with_location") }} as section_number,
-            {{ subsection_from_display("video_name_with_location") }}
-            as subsection_number,
+            section_number,
+            subsection_number,
             actor_id,
             video_id
-        from {{ ref("fact_video_plays") }}
+        from fact_video_plays
     ),
     fact_video_engagement_per_subsection as (
         select

--- a/models/video/subsection_video_engagement.sql
+++ b/models/video/subsection_video_engagement.sql
@@ -9,17 +9,46 @@
 }}
 
 with
+    plays as (
+        select
+            emission_time,
+            org,
+            course_key,
+            object_id,
+            video_duration,
+            video_position,
+            splitByString('/xblock/', object_id)[-1] as video_id,
+            actor_id
+        from {{ ref("video_playback_events") }}
+        where verb_id = 'https://w3id.org/xapi/video/verbs/played'
+    ),
+    fact_video_plays as (
+        select
+            plays.emission_time as emission_time,
+            plays.org as org,
+            plays.course_key as course_key,
+            plays.video_id as video_id,
+            blocks.section_number as section_number,
+            blocks.subsection_number as subsection_number,
+            plays.actor_id as actor_id
+        from plays
+        join
+            {{ ref("dim_course_blocks") }} blocks
+            on (
+                plays.course_key = blocks.course_key
+                and plays.video_id = blocks.block_id
+            )
+    ),
     viewed_subsection_videos as (
         select distinct
             date(emission_time) as viewed_on,
             org,
             course_key,
-            {{ section_from_display("video_name_with_location") }} as section_number,
-            {{ subsection_from_display("video_name_with_location") }}
-            as subsection_number,
+            section_number,
+            subsection_number,
             actor_id,
             video_id
-        from {{ ref("fact_video_plays") }}
+        from fact_video_plays
     ),
     fact_video_engagement_per_subsection as (
         select

--- a/models/video/unit_tests.yaml
+++ b/models/video/unit_tests.yaml
@@ -40,10 +40,10 @@ unit_tests:
     config:
       tags: 'ci'
     given:
-      - input: ref('fact_video_plays')
+      - input: ref('video_playback_events')
         format: sql
         rows: |
-          select * from fact_video_plays
+          select * from video_playback_events
       - input: ref('int_videos_per_subsection')
         format: sql
         rows: |
@@ -58,10 +58,10 @@ unit_tests:
     config:
       tags: 'ci'
     given:
-      - input: ref('fact_video_plays')
+      - input: ref('video_playback_events')
         format: sql
         rows: |
-          select * from fact_video_plays
+          select * from video_playback_events
       - input: ref('int_videos_per_subsection')
         format: sql
         rows: |

--- a/models/video/unit_tests.yaml
+++ b/models/video/unit_tests.yaml
@@ -44,6 +44,10 @@ unit_tests:
         format: sql
         rows: |
           select * from video_playback_events
+      - input: ref('dim_course_blocks')
+        format: sql
+        rows: |
+          select * from dim_course_blocks
       - input: ref('int_videos_per_subsection')
         format: sql
         rows: |
@@ -62,6 +66,10 @@ unit_tests:
         format: sql
         rows: |
           select * from video_playback_events
+      - input: ref('dim_course_blocks')
+        format: sql
+        rows: |
+          select * from dim_course_blocks
       - input: ref('int_videos_per_subsection')
         format: sql
         rows: |


### PR DESCRIPTION
### Description

The left-most table the section and subsection video engagement MVs were a view, which doesn't properly trigger inserts causing the MVs to be outdated.