### PR TITLE
fix: parse external_id to string instead of actor id to uuid and allo…

### DIFF
--- a/models/enrollment/fact_enrollments.sql
+++ b/models/enrollment/fact_enrollments.sql
@@ -25,4 +25,6 @@ select
 from enrollments
 join {{ ref("course_names") }} courses on enrollments.course_key = courses.course_key
 left outer join
-    {{ ref("dim_user_pii") }} users on toUUID(actor_id) = users.external_user_id
+    {{ ref("dim_user_pii") }} users
+    on (actor_id like 'mailto:%' and SUBSTRING(actor_id, 8) = users.email)
+    or actor_id = toString(users.external_user_id)

--- a/models/grading/fact_student_status.sql
+++ b/models/grading/fact_student_status.sql
@@ -29,4 +29,6 @@ join
     on fes.org = courses.org
     and fes.course_key = courses.course_key
 left outer join
-    {{ ref("dim_user_pii") }} users on toUUID(actor_id) = users.external_user_id
+    {{ ref("dim_user_pii") }} users
+    on (actor_id like 'mailto:%' and SUBSTRING(actor_id, 8) = users.email)
+    or actor_id = toString(users.external_user_id)

--- a/models/navigation/fact_navigation.sql
+++ b/models/navigation/fact_navigation.sql
@@ -23,4 +23,6 @@ join
         and navigation.block_id = blocks.block_id
     )
 left outer join
-    {{ ref("dim_user_pii") }} users on toUUID(actor_id) = users.external_user_id
+    {{ ref("dim_user_pii") }} users
+    on (actor_id like 'mailto:%' and SUBSTRING(actor_id, 8) = users.email)
+    or actor_id = toString(users.external_user_id)

--- a/models/navigation/fact_pageview_engagement.sql
+++ b/models/navigation/fact_pageview_engagement.sql
@@ -47,4 +47,6 @@ join
         and pv.block_id = course_blocks.block_id
     )
 left outer join
-    {{ ref("dim_user_pii") }} users on toUUID(pv.actor_id) = users.external_user_id
+    {{ ref("dim_user_pii") }} users
+    on (pv.actor_id like 'mailto:%' and SUBSTRING(pv.actor_id, 8) = users.email)
+    or pv.actor_id = toString(users.external_user_id)

--- a/models/problems/fact_problem_responses.sql
+++ b/models/problems/fact_problem_responses.sql
@@ -44,7 +44,9 @@ join
         and responses.problem_id = blocks.block_id
     )
 left outer join
-    {{ ref("dim_user_pii") }} users on toUUID(actor_id) = users.external_user_id
+    {{ ref("dim_user_pii") }} users
+    on (actor_id like 'mailto:%' and SUBSTRING(actor_id, 8) = users.email)
+    or actor_id = toString(users.external_user_id)
 group by
     -- multi-part questions include an extra record for the response to the first
     -- part of the question. this group by clause eliminates the duplicate record

--- a/models/video/fact_video_engagement.sql
+++ b/models/video/fact_video_engagement.sql
@@ -46,4 +46,6 @@ join
         and ve.block_id = course_blocks.block_id
     )
 left outer join
-    {{ ref("dim_user_pii") }} users on toUUID(ve.actor_id) = users.external_user_id
+    {{ ref("dim_user_pii") }} users
+    on (ve.actor_id like 'mailto:%' and SUBSTRING(ve.actor_id, 8) = users.email)
+    or ve.actor_id = toString(users.external_user_id)

--- a/models/video/fact_video_plays.sql
+++ b/models/video/fact_video_plays.sql
@@ -42,4 +42,6 @@ join
     {{ ref("dim_course_blocks_extended") }} blocks
     on (plays.course_key = blocks.course_key and plays.video_id = blocks.block_id)
 left outer join
-    {{ ref("dim_user_pii") }} users on toUUID(actor_id) = users.external_user_id
+    {{ ref("dim_user_pii") }} users
+    on (actor_id like 'mailto:%' and SUBSTRING(actor_id, 8) = users.email)
+    or actor_id = toString(users.external_user_id)


### PR DESCRIPTION
## Description

This PR addresses type compatibility issues within various views that involve actor_id fields, where actor_id values could represent either an email address (formatted as mailto:user@example.com) or a UUID. Previously, queries attempted to use toUUID(actor_id) for direct comparison with external_user_id in dim_user_pii, which caused errors when actor_id was not formatted as a UUID.

To resolve this, we modified the join condition for actor_id in all affected views:

-  Previous Condition: `toUUID(actor_id) = users.external_user_id`

- Updated Condition:

```sql
(actor_id LIKE 'mailto:%' AND SUBSTRING(actor_id, 8) = users.email)
OR actor_id = toString(users.external_user_id)
```

This conditional join ensures that:

1. When actor_id represents an email, it strips the mailto: prefix and compares the remaining string with the email field.
2. For UUID values, actor_id is cast to a String for compatibility with external_user_id in dim_user_pii.