### PR TITLE
fix: invert join side to user user_profiles as base table

### DIFF
--- a/models/users/user_pii.sql
+++ b/models/users/user_pii.sql
@@ -32,9 +32,9 @@ select
         concat('mailto:', email),
         ex.external_user_id::String
     ) as external_user_id,
-    up.username,
-    up.name,
-    up.email
+    up.username as username,
+    up.name as name,
+    up.email as email
 from most_recent_user_profile mrup
 left outer join
     {{ source("event_sink", "external_id") }} ex on mrup.user_id = ex.user_id

--- a/models/users/user_pii.sql
+++ b/models/users/user_pii.sql
@@ -4,7 +4,7 @@
         schema=env_var("ASPECTS_EVENT_SINK_DATABASE", "event_sink"),
         fields=[
             ("user_id", "Int32"),
-            ("external_user_id", "UUID"),
+            ("external_user_id", "String"),
             ("username", "String"),
             ("name", "String"),
             ("email", "String"),

--- a/models/users/user_pii.sql
+++ b/models/users/user_pii.sql
@@ -31,8 +31,8 @@ select
         empty(ex.external_user_id),
         concat('mailto:', email),
         ex.external_user_id::String
-    ),
-    ex.username,
+    ) as external_user_id,
+    up.username,
     up.name,
     up.email
 from most_recent_user_profile mrup


### PR DESCRIPTION
If no external ID records have been created we can still the `user_profile` information.