### PR TITLE
docs: Fill in missing doc descriptions and types

### DIFF
--- a/models/_docs/docs.md
+++ b/models/_docs/docs.md
@@ -6,12 +6,14 @@ The LMS can be configured to send different identifiers for an actor, but they a
 
 {% enddocs %}
 
+# TODO: link to Opaque Keys docs
 {% docs block_id %}
-The block's unique identifier
+The unique XBlock usage key for this block
 {% enddocs %}
 
+# TODO: link to Opaque Keys docs
 {% docs course_key %}
-The course key for the course
+The CourseKey for this course run
 {% enddocs %}
 
 {% docs course_name %}

--- a/models/_docs/docs.md
+++ b/models/_docs/docs.md
@@ -1,0 +1,118 @@
+
+{% docs actor_id %}
+The "id" portion of the xAPI Actor for this event. See: https://xapi.com/statements-101/#actor
+
+The LMS can be configured to send different identifiers for an actor, but they are all stored as Strings in ClickHouse: https://docs.openedx.org/projects/openedx-aspects/en/latest/technical_documentation/how-tos/changing_actor_identifier.html
+
+{% enddocs %}
+
+{% docs block_id %}
+The block's unique identifier
+{% enddocs %}
+
+{% docs course_key %}
+The course key for the course
+{% enddocs %}
+
+{% docs course_name %}
+The name of the course
+{% enddocs %}
+
+{% docs course_order %}
+The sort order of this block in the course across all course blocks
+{% enddocs %}
+
+{% docs course_run %}
+The course run for the course
+{% enddocs %}
+
+{% docs display_name %}
+The XBlock's display name
+{% enddocs %}
+
+{% docs dump_id %}
+The UUID of the event sink run that publishes to ClickHouse. When an event is published, all data is sent with the same dump_id.
+{% enddocs %}
+
+{% docs email %}
+The email address of the learner from the LMS user table. When Aspects PII syncing is off this will be empty.
+{% enddocs %}
+
+{% docs emission_time %}
+Timestamp, to the second, of when this event was emitted
+{% enddocs %}
+
+{% docs enrollment_mode %}
+The mode of enrollment such as "audit", "verified", or instance-specific values.
+{% enddocs %}
+
+{% docs enrollment_status %}
+Whether a learner is actively enrolled in a course
+{% enddocs %}
+
+{% docs event_id %}
+The unique identifier for the xAPI event, represented as a UUID v5 string, and based upon the actor id, verb, and event timestamp.
+{% enddocs %}
+
+{% docs graded %}
+Whether the block is graded
+{% enddocs %}
+
+{% docs id %}
+The primary key value for this row in the edx-platform MySQL database
+{% enddocs %}
+
+{% docs learner_name %}
+The full name of the learner based on their edx-platform UserProfile "name" field
+{% enddocs %}
+
+{% docs object_id %}
+The "id" portion of the xAPI Object resource identifier (IRI), stores as a String. See: https://xapi.com/statements-101/#object
+{% enddocs %}
+
+{% docs org %}
+The organization that the course belongs to, this value is extracted from the course key
+{% enddocs %}
+
+{% docs section_block_id %}
+The location of this subsection in the course, represented as <section location>:<subsection location>:0
+{% enddocs %}
+
+{% docs section_number %}
+The location of this section in the course, represented as <section location>:0:0
+{% enddocs %}
+
+{% docs section_with_name %}
+The name of the section this block belongs to, with section_number prepended
+{% enddocs %}
+
+{% docs subsection_block_id %}
+The unique identifier for the subsection block
+{% enddocs %}
+
+{% docs subsection_number %}
+The location of this subsection in the course, represented as <section location>:<subsection location>:0
+{% enddocs %}
+
+{% docs subsection_with_name %}
+The name of the subsection, with section_number prepended
+{% enddocs %}
+
+{% docs time_last_dumped %}
+The datetime of the event sink run that publishes to ClickHouse. When an event is published, all data is sent with the same time_last_dumped.
+{% enddocs %}
+
+{% docs username %}
+The username of the learner from the LMS user table. When Aspects PII syncing is off this will be empty.
+{% enddocs %}
+
+{% docs verb_id %}
+The "id" portion of the xAPI Verb for this event. See: https://xapi.com/statements-101/#verb
+{% enddocs %}
+
+
+{% docs object_tag_source %}
+Course objects and their associated tags from CMS events:  
+`COURSE_CREATED, XBLOCK_CREATED, LIBRARY_BLOCK_CREATED, CONTENT_OBJECT_ASSOCIATIONS_CHANGED`  
+and `post_save` Django signal on the Object Tag model
+{% enddocs %}

--- a/models/base/schema.yml
+++ b/models/base/schema.yml
@@ -6,28 +6,28 @@ models:
     columns:
       - name: event_id
         data_type: UUID
-        description: "The unique identifier for the event"
+        description: '{{ doc("event_id") }}'
       - name: verb_id
         data_type: String
-        description: "The xAPI verb identifier"
+        description: '{{ doc("verb_id") }}'
       - name: actor_id
         data_type: String
-        description: "The xAPI actor identifier"
+        description: '{{ doc("actor_id") }}'
       - name: object_id
         data_type: String
-        description: "The xAPI object identifier"
+        description: '{{ doc("object_id") }}'
       - name: course_id
         data_type: String
         description: "The fully-qualified course identifier URL"
       - name: course_key
         data_type: String
-        description: "The course key for the course"
+        description: '{{ doc("course_key") }}'
       - name: org
         data_type: String
-        description: "The organization that the course belongs to"
+        description: '{{ doc("org") }}'
       - name: emission_time
         data_type: DateTime64(6)
-        description: "The time the event was emitted"
+        description: '{{ doc("emission_time") }}'
       - name: event
         data_type: String
         description: "The xAPI event as a String"

--- a/models/base/sources.yml
+++ b/models/base/sources.yml
@@ -3,12 +3,18 @@ version: 2
 sources:
   - name: xapi
     database: "{{ env_var('ASPECTS_XAPI_DATABASE', 'xapi') }}"
-    description: "the xapi database in clickhouse"
+    description: "Clickhouse database for xapi events"
     tables:
       - name: xapi_events_all
         identifier: "{{ env_var('ASPECTS_VECTOR_RAW_XAPI_TABLE', 'xapi_events_all') }}"
         description: "Base table for raw xAPI events"
         columns:
           - name: event_id
+            type: UUID
+            description: '{{ doc("event_id") }}'
           - name: emission_time
+            type: DateTime64(6)
+            description: '{{ doc("emission_time") }}'
           - name: event
+            type: String
+            description: "The JSON representation of this xAPI event, stored as a String"

--- a/models/courses/schema.yml
+++ b/models/courses/schema.yml
@@ -6,28 +6,28 @@ models:
     columns:
       - name: org
         data_type: String
-        description: "The organization that the course belongs to"
+        description: '{{ doc("org") }}'
       - name: course_key
         data_type: String
-        description: "The course key for the course"
+        description: '{{ doc("course_key") }}'
       - name: course_name
         data_type: String
-        description: "The name of the course"
+        description: '{{ doc("course_name") }}'
       - name: course_run
         data_type: String
-        description: "The course run for the course"
+        description: '{{ doc("course_run") }}'
       - name: block_id
         data_type: String
-        description: "The block's unique identifier"
+        description: '{{ doc("block_id") }}'
       - name: block_name
         data_type: String
         description: "The block's name"
       - name: section_number
         data_type: String
-        description: "The section this block belongs to, formatted as <section location>:0:0"
+        description: '{{ doc("section_number") }}'
       - name: subsection_number
         data_type: String
-        description: "The subsection this block belongs to, formatted as <section location>:<subsection location>:0"
+        description: '{{ doc("subsection_number") }}'  
       - name: hierarchy_location
         data_type: String
         description: "The full section:subsection:unit hierarchy in which this block belongs"
@@ -36,10 +36,10 @@ models:
         description: "The block's display name with section, subsection, and unit prepended to the name. This provides additional context when looking at block names and can help data consumers understand which block they are analyzing"
       - name: course_order
         data_type: Int32
-        description: "The sort order of this block in the course across all course blocks"
+        description: '{{ doc("course_order") }}'
       - name: graded
         data_type: Boolean
-        description: "Whether the block is graded"
+        description: '{{ doc("graded") }}'
       - name: block_type
         data_type: String
         description: "The type of block. This can be a section, subsection, unit, or the block type"
@@ -55,16 +55,16 @@ models:
         description: "The name of the block"
       - name: course_key
         data_type: String
-        description: "The course which the block belongs to"
+        description: '{{ doc("course_key") }}'
       - name: graded
         data_type: Boolean
-        description: "Whether the block is graded"
+        description: '{{ doc("graded") }}'
       - name: display_name_with_location
         data_type: String
         description: "The block's display name with section, subsection, and unit prepended to the name. This provides additional context when looking at block names and can help data consumers understand which block they are analyzing"
       - name: course_order
         data_type: Int32
-        description: "The sort order of this block in the course across all course blocks"
+        description: '{{ doc("course_order") }}'
       - name: section
         data_type: Int32
         description: "The section number that this block falls under in the course. Starts at 1."
@@ -76,10 +76,10 @@ models:
         description: "The unit number that this block falls under in the subsection. Starts at 1."
       - name: dump_id
         data_type: UUID
-        description: "The UUID of the event sink run that published this block to ClickHouse. When a course is published all blocks inside it are sent with the same dump_id."
+        description: '{{ doc("dump_id") }}'
       - name: time_last_dumped
         data_type: String
-        description: "The Datetime of the event sink run that published this block to ClickHouse. When a course is published all blocks inside it are sent with the same time_last_dumped."
+        description: '{{ doc("time_last_dumped") }}'
 
   - name: most_recent_course_blocks
     description: "A materialized view of course blocks with their display names and additional metadata. Only stores the most recent row per block location."
@@ -92,16 +92,16 @@ models:
         description: "The name of the block"
       - name: course_key
         data_type: String
-        description: "The course which the block belongs to"
+        description: '{{ doc("course_key") }}'
       - name: graded
         data_type: Boolean
-        description: "Whether the block is graded"
+        description: '{{ doc("graded") }}'
       - name: display_name_with_location
         data_type: String
         description: "The block's display name with section, subsection, and unit prepended to the name. This provides additional context when looking at block names and can help data consumers understand which block they are analyzing"
       - name: course_order
         data_type: Int32
-        description: "The sort order of this block in the course across all course blocks"
+        description: '{{ doc("course_order") }}'
       - name: section
         data_type: Int32
         description: "The section number that this block falls under in the course. Starts at 1."
@@ -113,54 +113,54 @@ models:
         description: "The unit number that this block falls under in the subsection. Starts at 1."
       - name: dump_id
         data_type: UUID
-        description: "The UUID of the event sink run that published this block to ClickHouse. When a course is published all blocks inside it are sent with the same dump_id."
+        description: '{{ doc("dump_id") }}'
       - name: time_last_dumped
         data_type: String
-        description: "The datetime of the event sink run that published this block to ClickHouse. When a course is published all blocks inside it are sent with the same time_last_dumped."
+        description: '{{ doc("time_last_dumped") }}'
 
   - name: course_names
-    description: "A table of courses with their names"
+    description: "A dictionary of courses with their names"
     columns:
       - name: course_key
         data_type: String
-        description: "The course key for the course"
+        description: '{{ doc("course_key") }}'
       - name: course_name
         data_type: String
-        description: "The name of the course"
+        description: '{{ doc("course_name") }}'
       - name: course_run
         data_type: String
-        description: "The course run for the course"
+        description: '{{ doc("course_run") }}'
       - name: org
         data_type: String
-        description: "The organization that the course belongs to"
+        description: '{{ doc("org") }}'
 
   - name: dim_course_blocks_extended
     description: "dim_course_blocks with section and subsection names joined into the data."
     columns:
       - name: org
         data_type: String
-        description: "The organization that the course belongs to"
+        description: '{{ doc("org") }}'
       - name: course_key
         data_type: String
-        description: "The course key for the course"
+        description: '{{ doc("course_key") }}'
       - name: course_name
         data_type: String
-        description: "The name of the course"
+        description: '{{ doc("course_name") }}'
       - name: course_run
         data_type: String
-        description: "The course run for the course"
+        description: '{{ doc("course_run") }}'
       - name: block_id
         data_type: String
-        description: "The block's unique identifier"
+        description: '{{ doc("block_id") }}'
       - name: block_name
         data_type: String
         description: "The block's name"
       - name: section_number
         data_type: String
-        description: "The section this block belongs to, formatted as <section location>:0:0"
+        description: '{{ doc("section_number") }}'
       - name: subsection_number
         data_type: String
-        description: "The subsection this block belongs to, formatted as <section location>:<subsection location>:0"
+        description: '{{ doc("subsection_number") }}'
       - name: hierarchy_location
         data_type: String
         description: "The full section:subsection:unit hierarchy in which this block belongs"
@@ -169,16 +169,16 @@ models:
         description: "The block's display name with section, subsection, and unit prepended to the name. This provides additional context when looking at block names and can help data consumers understand which block they are analyzing"
       - name: graded
         data_type: Boolean
-        description: "Whether the block is graded"
+        description: '{{ doc("graded") }}'
       - name: block_type
         data_type: String
         description: "The type of block. This can be a section, subsection, unit, or the block type"
       - name: section_with_name
         data_type: String
-        description: "The name of the section this block belongs to, with section_number prepended"
+        description: '{{ doc("section_with_name") }}'
       - name: subsection_with_name
         data_type: String
-        description: "The name of the section this subsection belongs to, with subsection_number prepended"
+        description: '{{ doc("subsection_with_name") }}'
       - name: course_order
         data_type: Int32
-        description: "The sort order of this block in the course across all course blocks"
+        description: '{{ doc("course_order") }}'

--- a/models/courses/sources.yml
+++ b/models/courses/sources.yml
@@ -3,32 +3,79 @@ version: 2
 sources:
   - name: event_sink
     database: "{{ env_var('ASPECTS_EVENT_SINK_DATABASE', 'event_sink')}}"
+    description: "Clickhouse database for event driven and reporting tables"
     tables:
 
       - name: course_blocks
+        description: XBlock data from CMS `COURSE_PUBLISHED` events
         columns:
           - name: org
+            description: '{{ doc("org")}}'
+            type: String
           - name: course_key
+            description: '{{ doc("course_key")}}'
+            type: String
           - name: location
+            description: "The location of the block"
+            type: String
           - name: display_name
+            description: "The name of the block"
+            type: String
           - name: xblock_data_json
+            description: "Json string containing xblock data"
+            type: String
           - name: order
+            description: '{{ doc("course_order")}}'
+            type: Int32
           - name: edited_on
+            description: "Date the course block was edited"
+            type: String
           - name: dump_id
+            description: '{{ doc("dump_id") }}'
+            type: UUID
           - name: time_last_dumped
+            description: '{{ doc("time_last_dumped") }}'
+            type: String
 
       - name: course_overviews
+        description: Course metadata from CMS `COURSE_PUBLISHED` events
         columns:
           - name: org
+            description: '{{ doc("org")}}' 
+            type: String
           - name: course_key
+            description: '{{ doc("course_key")}}'
+            type: String
           - name: display_name
+            description: "The name of the block"
+            type: String
           - name: course_start
+            description: "Course start date"
+            type: String
           - name: course_end
+            description: "Course end date"
+            type: String
           - name: enrollment_start
+            description: "Enrollment start date"
+            type: String
           - name: enrollment_end
+            description: "Enrollment end date"
+            type: String
           - name: self_paced
+            description: "If the course is self paced"
+            type: Boolean
           - name: course_data_json
+            description: "Json string containing course data"
+            type: String
           - name: created
+            description: "Course create date"
+            type: String
           - name: modified
-          - name: dump_id
+            description: "Course modified date"
+            type: String
+          - name: dump_id            
+            description: '{{ doc("dump_id") }}'
+            type: UUID
           - name: time_last_dumped
+            description: '{{ doc("time_last_dumped") }}'
+            type: String

--- a/models/enrollment/schema.yml
+++ b/models/enrollment/schema.yml
@@ -6,90 +6,90 @@ models:
     columns:
       - name: emission_time
         data_type: DateTime
-        description: "Timestamp, to the second, of when this event was emitted"
+        description: '{{ doc("emission_time") }}'
       - name: org
         data_type: String
-        description: "The organization that the course belongs to"
+        description: '{{ doc("org") }}'
       - name: course_key
         data_type: String
-        description: "The course key for the course"
+        description: '{{ doc("course_key") }}'
       - name: course_name
         data_type: String
-        description: "The name of the course"
+        description: '{{ doc("course_name") }}'
       - name: course_run
         data_type: String
-        description: "The course run for the course"
+        description: '{{ doc("course_run") }}'
       - name: actor_id
         data_type: String
-        description: "The xAPI actor identifier"
+        description: '{{ doc("actor_id") }}'
       - name: enrollment_mode
         data_type: LowCardinality(String)
-        description: "The mode of enrollment"
+        description: '{{ doc("enrollment_mode") }}'
       - name: enrollment_status
-        description: "Whether a learner is actively enrolled in a course"
+        description: '{{ doc("enrollment_status") }}'
         data_tests:
           - accepted_values:
               values: ["registered", "unregistered"]
         data_type: String
       - name: username
         data_type: String
-        description: "The username of the learner"
+        description: '{{ doc("username") }}'
       - name: name
         data_type: String
-        description: "The full name of the learner"
+        description: '{{ doc("learner_name") }}'
       - name: email
         data_type: String
-        description: "The email address of the learner"
+        description: '{{ doc("email") }}'
 
   - name: enrollment_events
     description: "A materialized view for xAPI events related to course enrollment"
     columns:
       - name: event_id
         data_type: UUID
-        description: "The unique identifier for the event"
+        description: '{{ doc("event_id") }}'
       - name: emission_time
         data_type: DateTime
-        description: "The time the event was emitted"
+        description: '{{ doc("emission_time") }}'
       - name: actor_id
         data_type: String
-        description: "The xAPI actor identifier"
+        description: '{{ doc("actor_id") }}'
       - name: object_id
         data_type: String
-        description: "The xAPI object identifier"
+        description: '{{ doc("object_id") }}'
       - name: course_key
         data_type: String
-        description: "The course identifier"
+        description: '{{ doc("course_key") }}'
       - name: org
         data_type: String
-        description: "The organization that the course belongs to"
+        description: '{{ doc("org") }}'
       - name: verb_id
         data_type: String
-        description: "The xAPI verb identifier"
+        description: '{{ doc("verb_id") }}'
       - name: enrollment_mode
         data_type: String
-        description: "The mode of enrollment"
+        description: '{{ doc("enrollment_mode") }}'
 
   - name: fact_enrollment_status
     description: One record per learner per course for the most recent enrollment status
     columns:
       - name: org
         data_type: String
-        description: "The organization that the course belongs to"
+        description: '{{ doc("org") }}'
       - name: course_key
         data_type: String
-        description: "The course key for the course"
+        description: '{{ doc("course_key") }}'
       - name: actor_id
         data_type: String
-        description: "The xAPI actor identifier"
+        description: '{{ doc("actor_id") }}'
       - name: enrollment_status
         data_type: String
-        description: "Whether a learner is actively enrolled in a course"
+        description: '{{ doc("enrollment_status") }}'
         data_tests:
           - accepted_values:
               values: ["registered", "unregistered"]
       - name: enrollment_mode
         data_type: String
-        description: "The mode of enrollment"
+        description: '{{ doc("enrollment_mode") }}'
       - name: emission_time
-        data_type: DateTime
-        description: "The time the enrollment status was emitted"
+        data_type: Strin
+        description: '{{ doc("emission_time") }}'

--- a/models/grading/schema.yml
+++ b/models/grading/schema.yml
@@ -6,19 +6,19 @@ models:
     columns:
       - name: org
         data_type: String
-        description: "The organization that the course belongs to"
+        description: '{{ doc("org") }}'
       - name: course_key
         data_type: String
-        description: "The course key for the course"
+        description: '{{ doc("course_key") }}'
       - name: actor_id
         data_type: String
-        description: "The xAPI actor identifier"
+        description: '{{ doc("actor_id") }}'
       - name: course_grade
         data_type: float64
         description: "The most recent grade for the learner"
       - name: emission_time
         data_type: DateTime
-        description: "The time the event was emitted"
+        description: '{{ doc("emission_time") }}'
 
 
   - name: fact_learner_course_status
@@ -26,16 +26,16 @@ models:
     columns:
       - name: org
         data_type: String
-        description: "The organization that the course belongs to"
+        description: '{{ doc("org") }}'
       - name: course_key
         data_type: String
-        description: "The course key for the course"
+        description: '{{ doc("course_key") }}'
       - name: actor_id
         data_type: String
-        description: "The xAPI actor identifier"
+        description: '{{ doc("actor_id") }}'
       - name: emission_time
         data_type: DateTime
-        description: "The time the event was emitted"
+        description: '{{ doc("emission_time") }}'
       - name: approving_state
         data_type: String
         description: "The most recent approving_state of the learner's grade"
@@ -48,25 +48,25 @@ models:
     columns:
       - name: event_id
         data_type: UUID
-        description: "The unique identifier for the event"
+        description: '{{ doc("event_id") }}'
       - name: emission_time
         data_type: DateTime
-        description: "The time the event was emitted"
+        description: '{{ doc("emission_time") }}'
       - name: actor_id
         data_type: String
-        description: "The xAPI actor identifier"
+        description: '{{ doc("actor_id") }}'
       - name: object_id
         data_type: String
-        description: "The xAPI object identifier"
+        description: '{{ doc("object_id") }}'
       - name: course_key
         data_type: String
-        description: "The course identifier"
+        description: '{{ doc("course_key") }}'
       - name: org
         data_type: String
-        description: "The organization that the course belongs to"
+        description: '{{ doc("org") }}'
       - name: verb_id
         data_type: String
-        description: "The xAPI verb identifier"
+        description: '{{ doc("verb_id") }}'
       - name: scaled_score
         data_type: float64
         description: "A ratio between 0 and 1, inclusive, of the learner's grade"
@@ -79,27 +79,27 @@ models:
     columns:
       - name: org
         data_type: String
-        description: "The organization that the course belongs to"
+        description: '{{ doc("org") }}'
       - name: course_key
         data_type: String
-        description: "The course key for the course"
+        description: '{{ doc("course_key") }}'
       - name: actor_id
         data_type: String
-        description: "The xAPI actor identifier"
+        description: '{{ doc("actor_id") }}'
       - name: course_name
         data_type: String
-        description: "The name of the course"
+        description: '{{ doc("course_name") }}'
       - name: course_run
         data_type: String
-        description: "The course run for the course"
+        description: '{{ doc("course_run") }}'
       - name: approving_state
         data_type: String
         description: "The most recent approving state for the learner"
       - name: enrollment_mode
         data_type: String
-        description: "The mode of enrollment"
+        description: '{{ doc("enrollment_mode") }}'
       - name: enrollment_status
-        description: "Whether a learner is actively enrolled in a course"
+        description: '{{ doc("enrollment_status") }}'
         data_tests:
           - accepted_values:
               values: ["registered", "unregistered"]
@@ -111,13 +111,13 @@ models:
         description: "A displayable value of grades sorted into 10% buckets. Useful for grouping grades together to show high-level learner performance"
       - name: username
         data_type: String
-        description: "The username of the learner"
+        description: '{{ doc("username") }}'
       - name: name
         data_type: String
-        description: "The full name of the learner"
+        description: '{{ doc("learner_name") }}'
       - name: email
         data_type: String
-        description: "The email address of the learner"
+        description: '{{ doc("email") }}'
       - name: enrolled_at
         data_type: DateTime
         description: "The timestamp, to the second, of the most recent enrollment action for this learner and course."

--- a/models/instance/schema.yml
+++ b/models/instance/schema.yml
@@ -39,16 +39,16 @@ models:
         description: "Time of summary, truncated to the day"
       - name: course_name
         data_type: String
-        description: "The name of the course"
+        description: '{{ doc("course_name") }}'
       - name: course_key
         data_type: String
-        description: "The course key for the course"
+        description: '{{ doc("course_key") }}'
       - name: enrollment_mode
         data_type: String
-        description: "The name of the enrollment mode (ex: audit, honor)"
+        description: '{{ doc("enrollment_mode") }}'
       - name: enrollment_status
         data_type: String
-        description: "The type of enrollment event  (ex: registered, unregistered)"
+        description: '{{ doc("enrollment_status") }}'
         data_tests:
           - accepted_values:
               values: [ "registered", "unregistered" ]

--- a/models/navigation/schema.yml
+++ b/models/navigation/schema.yml
@@ -6,25 +6,25 @@ models:
     columns:
       - name: event_id
         data_type: UUID
-        description: "The unique identifier for the event"
+        description: '{{ doc("event_id") }}'
       - name: emission_time
         data_type: DateTime
-        description: "Timestamp, to the second, of when this event was emitted"
+        description: '{{ doc("emission_time") }}'
       - name: actor_id
         data_type: String
-        description: "The xAPI actor identifier"
+        description: '{{ doc("actor_id") }}'
       - name: block_id
         data_type: String
-        description: "The LMS object identifier"
+        description: '{{ doc("block_id") }}'
       - name: course_key
         data_type: String
-        description: "The course identifier"
+        description: '{{ doc("course_key") }}'
       - name: org
         data_type: String
-        description: "The organization that the course belongs to"
+        description: '{{ doc("org") }}'
       - name: verb_id
         data_type: String
-        description: "The xAPI verb identifier"
+        description: '{{ doc("verb_id") }}'
       - name: object_type
         data_type: String
         description: "The type of object that the learner interacted with"
@@ -40,25 +40,25 @@ models:
     columns:
       - name: emission_time
         data_type: DateTime
-        description: "Timestamp, to the second, of when this event was emitted"
+        description: '{{ doc("emission_time") }}'
       - name: org
         data_type: String
-        description: "The organization that the course belongs to"
+        description: '{{ doc("org") }}'
       - name: course_key
         data_type: String
-        description: "The course identifier"
+        description: '{{ doc("course_key") }}'
       - name: course_name
         data_type: String
-        description: "The name of the course"
+        description: '{{ doc("course_name") }}'
       - name: course_run
         data_type: String
-        description: "The course run for the course"
+        description: '{{ doc("course_run") }}'
       - name: actor_id
         data_type: String
-        description: "The xAPI actor identifier"
+        description: '{{ doc("actor_id") }}'
       - name: block_id
         data_type: String
-        description: "The LMS object identifier"
+        description: '{{ doc("block_id") }}'
       - name: block_name
         data_type: String
         description: "The block's name"
@@ -76,16 +76,16 @@ models:
         description: "The tab in the unit navigation bar that the learner selected to navigate to"
       - name: username
         data_type: String
-        description: "The username of the learner"
+        description: '{{ doc("username") }}'
       - name: name
         data_type: String
-        description: "The full name of the learner"
+        description: '{{ doc("learner_name") }}'
       - name: email
         data_type: String
-        description: "The email address of the learner"
+        description: '{{ doc("email") }}'
       - name: course_order
         data_type: Int32
-        description: "The sort order of this block in the course across all course blocks"
+        description: '{{ doc("course_order") }}'
 
   - name: fact_navigation_completion
     description: "A view for analyzing how many pages a learner has visited in a section or subsection"
@@ -95,99 +95,99 @@ models:
         description: "The Date the page was visited"
       - name: org
         data_type: String
-        description: "The organization that the course belongs to"
+        description: '{{ doc("org") }}'
       - name: course_key
         data_type: String
-        description: "The course identifier"
+        description: '{{ doc("course_key") }}'
       - name: course_name
         data_type: String
-        description: "The course name"
+        description: '{{ doc("course_name") }}'
       - name: course_run
         data_type: String
-        description: "The course run for the course"
+        description: '{{ doc("course_run") }}'
       - name: section_with_name
         data_type: String
-        description: "The name of the section"
+        description: '{{ doc("section_with_name") }}'
       - name: subsection_with_name
         data_type: String
-        description: "The name of the subsection"
+        description: '{{ doc("subsection_with_name") }}'
       - name: page_count
         data_type: UInt64
         description: "The number of pages in the associated subsection"
       - name: actor_id
         data_type: String
-        description: "The xAPI actor identifier"
+        description: '{{ doc("actor_id") }}'
       - name: block_id
         data_type: String
-        description: "The ID of the specific page visited"
+        description: '{{ doc("block_id") }}'
       - name: username
         data_type: String
-        description: "The username of the learner"
+        description: '{{ doc("username") }}'
       - name: name
         data_type: String
-        description: "The full name of the learner"
+        description: '{{ doc("learner_name") }}'
       - name: email
         data_type: String
-        description: "The email address of the learner"
+        description: '{{ doc("email") }}'
       - name: course_order
         data_type: Int32
-        description: "The sort order of this block in the course across all course blocks"
+        description: '{{ doc("course_order") }}'
 
   - name: int_pages_per_subsection
     description: "A view for analyzing the number of pages in each subsection"
     columns:
       - name: org
         data_type: String
-        description: The organization that the course belongs to
+        description: '{{ doc("org") }}'
       - name: course_key
         data_type: String
-        description: The course identifier
+        description: '{{ doc("course_key") }}'
       - name: section_number
         data_type: String
-        description: The section number
+        description: '{{ doc("section_number") }}'
       - name: section_with_name
         data_type: String
-        description: The section number and name
+        description: '{{ doc("section_with_name") }}'
       - name: subsection_number
         data_type: String
-        description: The subsection number
+        description: '{{ doc("subsection_number") }}'
       - name: subsection_with_name
         data_type: String
-        description: The subsection number and name
+        description: '{{ doc("subsection_with_name") }}'
       - name: course_order
         data_type: Int32
-        description: "The sort order of this block in the course across all course blocks"
+        description: '{{ doc("course_order") }}'
       - name: graded
         data_type: Boolean
-        description: "Whether the unit is graded"
+        description: '{{ doc("graded") }}'
       - name: item_count
         data_type: UInt64
         description: The number of pages in the associated subsection
       - name: subsection_block_id
         data_type: String
-        description: The unique identifier for the subsection block
+        description: '{{ doc("subsection_block_id") }}'
       - name: section_block_id
         data_type: String
-        description: The unique identifier for the section block
+        description: '{{ doc("section_block_id") }}'
 
   - name: fact_pageview_engagement
     description: "A view for analyzing the number of page views per learner per section and subsection"
     columns:
       - name: org
         data_type: String
-        description: "The organization that the course belongs to"
+        description: '{{ doc("org") }}'
       - name: course_key
         data_type: String
-        description: "The course identifier"
+        description: '{{ doc("course_key") }}'
       - name: course_run
         data_type: String
-        description: "The course run for the course"
+        description: '{{ doc("course_run") }}'
       - name: section_with_name
         data_type: String
-        description: "The name of the section"
+        description: '{{ doc("section_with_name") }}'
       - name: subsection_with_name
         data_type: String
-        description: "The name of the subsection"
+        description: '{{ doc("subsection_with_name") }}'
       - name: section_subsection_name
         data_type: String
         description: "The name of the section or subsection"
@@ -199,51 +199,51 @@ models:
               values: ["section", "subsection"]
       - name: actor_id
         data_type: String
-        description: "The xAPI actor identifier"
+        description: '{{ doc("actor_id") }}'
       - name: section_subsection_page_engagement
         data_type: UInt64
         description: "The total number of times a learner viewed pages in this section or subsection"
       - name: username
         data_type: String
-        description: "The username of the learner"
+        description: '{{ doc("username") }}'
       - name: name
         data_type: String
-        description: "The full name of the learner"
+        description: '{{ doc("learner_name") }}'
       - name: email
         data_type: String
-        description: "The email address of the learner"
+        description: '{{ doc("email") }}'
 
   - name: fact_learner_last_course_visit
     description: "A materialized view that stores a learners last navigation event timestamp for a course"
     columns:
       - name: org
         data_type: String
-        description: "The organization that the course belongs to"
+        description: '{{ doc("org") }}'
       - name: course_key
         data_type: String
-        description: "The course identifier"
+        description: '{{ doc("course_key") }}'
       - name: actor_id
         data_type: String
-        description: "The xAPI actor identifier"
+        description: '{{ doc("actor_id") }}'
       - name: emission_time
         data_type: DateTime
-        description: "Timestamp, to the second, of when this event was emitted"
+        description: '{{ doc("emission_time") }}'
 
   - name: section_page_engagement
     description: "A record per course per section per learner with their engagement level"
     columns:
       - name: org
         data_type: String
-        description: "The organization that the course belongs to"
+        description: '{{ doc("org") }}'
       - name: course_key
         data_type: String
-        description: "The course key for the course"
+        description: '{{ doc("course_key") }}'
       - name: actor_id
         data_type: String
-        description: "The xAPI actor identifier"
+        description: '{{ doc("actor_id") }}'
       - name: section_block_id
         data_type: String
-        description: "The unique identifier for the section block"
+        description: '{{ doc("section_block_id") }}'
       - name: engagement_level
         data_type: String
         description: "The engagement level of the learner with the section"
@@ -259,16 +259,16 @@ models:
     columns:
       - name: org
         data_type: String
-        description: "The organization that the course belongs to"
+        description: '{{ doc("org") }}'
       - name: course_key
         data_type: String
-        description: "The course key for the course"
+        description: '{{ doc("course_key") }}'
       - name: actor_id
         data_type: String
-        description: "The xAPI actor identifier"
+        description: '{{ doc("actor_id") }}'
       - name: subsection_block_id
         data_type: String
-        description: "The unique identifier for the subsection block"
+        description: '{{ doc("subsection_block_id") }}'
       - name: engagement_level
         data_type: String
         description: "The engagement level of the learner with the subsection"

--- a/models/problems/schema.yml
+++ b/models/problems/schema.yml
@@ -6,19 +6,19 @@ models:
     columns:
       - name: emission_time
         data_type: DateTime
-        description: "Timestamp, to the second, of when this event was emitted"
+        description: '{{ doc("emission_time") }}'
       - name: org
         data_type: String
-        description: "The organization that the course belongs to"
+        description: '{{ doc("org") }}'
       - name: course_key
         data_type: String
-        description: "The course key for the course"
+        description: '{{ doc("course_key") }}'
       - name: course_name
         data_type: String
-        description: "The name of the course"
+        description: '{{ doc("course_name") }}'
       - name: course_run
         data_type: String
-        description: "The course run for the course"
+        description: '{{ doc("course_run") }}'
       - name: problem_id
         data_type: String
         description: "The problem's unique identifier"
@@ -33,10 +33,10 @@ models:
         description: "An anchor tag with a link to the problem"
       - name: graded
         data_type: Bool
-        description: "Whether the block is graded"
+        description: '{{ doc("graded") }}'
       - name: actor_id
         data_type: String
-        description: "The xAPI actor identifier"
+        description: '{{ doc("actor_id") }}'
       - name: responses
         description: "The responses for this submission. If a problem has multiple parts, values for all parts will be in this field"
         data_type: String
@@ -48,41 +48,41 @@ models:
         data_type: Int16
       - name: graded
         data_type: bool
-        description: "Boolean indicating this block is graded"
+        description: '{{ doc("graded") }}'
       - name: interaction_type
         data_type: String
         description: "The type of interaction - e.g. multiple choice"
       - name: username
         data_type: String
-        description: "The username of the learner"
+        description: '{{ doc("username") }}'
       - name: name
         data_type: String
-        description: "The full name of the learner"
+        description: '{{ doc("learner_name") }}'
       - name: email
         data_type: String
-        description: "The email address of the learner"
+        description: '{{ doc("email") }}'
       - name: course_order
         data_type: Int32
-        description: "The sort order of this block in the course across all course blocks"
+        description: '{{ doc("course_order") }}'
 
   - name: int_problem_hints
     description: "Internal table for problem hints"
     columns:
       - name: emission_time
         data_type: DateTime
-        description: "Timestamp, to the second, of when this event was emitted"
+        description: '{{ doc("emission_time") }}'
       - name: org
         data_type: String
-        description: "The organization that the course belongs to"
+        description: '{{ doc("org") }}'
       - name: course_key
         data_type: String
-        description: "The course key for the course"
+        description: '{{ doc("course_key") }}'
       - name: course_name
         data_type: String
-        description: "The name of the course"
+        description: '{{ doc("course_name") }}'
       - name: course_run
         data_type: String
-        description: "The course run for the course"
+        description: '{{ doc("course_run") }}'
       - name: problem_id
         data_type: String
         description: "The problem's unique identifier"
@@ -94,32 +94,32 @@ models:
         description: "The problem's display name with section, subsection, and unit prepended to the name. This provides additional context when looking at problem names and can help data consumers understand which problem they are analyzing"
       - name: actor_id
         data_type: String
-        description: "The xAPI actor identifier"
+        description: '{{ doc("actor_id") }}'
       - name: help_type
         data_type: String
         description: "The type of help requested"
       - name: course_order
         data_type: Int32
-        description: "The sort order of this block in the course across all course blocks"
+        description: '{{ doc("course_order") }}'
 
   - name: int_problem_results
     description: "Internal table for problem results"
     columns:
       - name: emission_time
         data_type: DateTime
-        description: "Timestamp, to the second, of when this event was emitted"
+        description: '{{ doc("emission_time") }}'
       - name: org
         data_type: String
-        description: "The organization that the course belongs to"
+        description: '{{ doc("org") }}'
       - name: course_key
         data_type: String
-        description: "The course key for the course"
+        description: '{{ doc("course_key") }}'
       - name: course_name
         data_type: String
-        description: "The name of the course"
+        description: '{{ doc("course_name") }}'
       - name: course_run
         data_type: String
-        description: "The course run for the course"
+        description: '{{ doc("course_run") }}'
       - name: problem_id
         data_type: String
         description: "The problem's unique identifier"
@@ -134,7 +134,7 @@ models:
         description: "An anchor tag with a link to the problem"
       - name: actor_id
         data_type: String
-        description: "The xAPI actor identifier"
+        description: '{{ doc("actor_id") }}'
       - name: responses
         data_type: String
         description: "The responses for this submission. If a problem has multiple parts, values for all parts will be in this field"
@@ -146,38 +146,38 @@ models:
         description: "Number indicating which attempt this was"
       - name: graded
         data_type: bool
-        description: "Boolean indicating this block is graded"
+        description: '{{ doc("graded") }}'
       - name: interaction_type
         data_type: String
         description: "The type of interaction - e.g. multiple choice"
       - name: course_order
         data_type: Int32
-        description: "The sort order of this block in the course across all course blocks"
+        description: '{{ doc("course_order") }}'
 
   - name: problem_events
     description: "Problem events"
     columns:
       - name: event_id
         data_type: UUID
-        description: "The unique identifier for the event"
+        description: '{{ doc("event_id") }}'
       - name: emission_time
         data_type: DateTime
-        description: "The time the event was emitted"
+        description: '{{ doc("emission_time") }}'
       - name: actor_id
         data_type: String
-        description: "The xAPI actor identifier"
+        description: '{{ doc("actor_id") }}'
       - name: object_id
         data_type: String
-        description: "The xAPI object identifier"
+        description: '{{ doc("object_id") }}'
       - name: course_key
         data_type: String
-        description: "The course identifier"
+        description: '{{ doc("course_key") }}'
       - name: org
         data_type: String
-        description: "The organization that the course belongs to"
+        description: '{{ doc("org") }}'
       - name: verb_id
         data_type: String
-        description: "The xAPI verb identifier"
+        description: '{{ doc("verb_id") }}'
       - name: responses
         data_type: String
         description: "The responses for this submission. If a problem has multiple parts, values for all parts will be in this field"
@@ -202,22 +202,22 @@ models:
     columns:
       - name: org
         data_type: String
-        description: "The organization that the course belongs to"
+        description: '{{ doc("org") }}'
       - name: course_key
         data_type: String
-        description: "The course key for the course"
+        description: '{{ doc("course_key") }}'
       - name: section_number
         data_type: String
-        description: "The location of this section in the course, represented as section:0:0"
+        description: '{{ doc("section_number") }}'
       - name: section_with_name
         data_type: String
-        description: "The name of the section this subsection belongs to, with section_number prepended"
+        description: '{{ doc("section_with_name") }}'
       - name: subsection_number
         data_type: String
-        description: "The location of this subsection in the course, represented as section:subsection:0"
+        description: '{{ doc("subsection_number") }}'
       - name: subsection_with_name
         data_type: String
-        description: "The name of the subsection, with section_number prepended"
+        description: '{{ doc("subsection_with_name") }}'
       - name: graded
         data_type: bool
         description: "Whether this subsection block is graded"
@@ -226,29 +226,29 @@ models:
         description: "The number of problems in this subsection"
       - name: course_order
         data_type: Int32
-        description: "The sort order of this block in the course across all course blocks"
+        description: '{{ doc("course_order") }}'
       - name: subsection_block_id
         data_type: String
-        description: "The unique identifier for the subsection block"
+        description: '{{ doc("subsection_block_id") }}'
       - name: section_block_id
         data_type: String
-        description: "The unique identifier for the section block"
+        description: '{{ doc("section_block_id") }}'
 
   - name: responses
     description: "A record per course per problem per learner with their last attempt and first success"
     columns:
       - name: org
         data_type: String
-        description: "The organization that the course belongs to"
+        description: '{{ doc("org") }}'
       - name: course_key
         data_type: String
-        description: "The course key for the course"
+        description: '{{ doc("course_key") }}'
       - name: problem_id
         data_type: String
         description: "The problem's unique identifier"
       - name: actor_id
         data_type: String
-        description: "The xAPI actor identifier"
+        description: '{{ doc("actor_id") }}'
       - name: first_success_at
         data_type: Nullable(DateTime)
         description: "The timestamp of the first successful attempt"
@@ -264,16 +264,16 @@ models:
     columns:
       - name: org
         data_type: String
-        description: "The organization that the course belongs to"
+        description: '{{ doc("org") }}'
       - name: course_key
         data_type: String
-        description: "The course key for the course"
+        description: '{{ doc("course_key") }}'
       - name: actor_id
         data_type: String
-        description: "The xAPI actor identifier"
+        description: '{{ doc("actor_id") }}'
       - name: section_block_id
         data_type: String
-        description: "The unique identifier for the section block"
+        description: '{{ doc("section_block_id") }}'
       - name: engagement_level
         data_type: String
         description: "The engagement level of the learner with the section"
@@ -289,16 +289,16 @@ models:
     columns:
       - name: org
         data_type: String
-        description: "The organization that the course belongs to"
+        description: '{{ doc("org") }}'
       - name: course_key
         data_type: String
-        description: "The course key for the course"
+        description: '{{ doc("course_key") }}'
       - name: actor_id
         data_type: String
-        description: "The xAPI actor identifier"
+        description: '{{ doc("actor_id") }}'
       - name: subsection_block_id
         data_type: String
-        description: "The unique identifier for the subsection block"
+        description: '{{ doc("subsection_block_id") }}'
       - name: engagement_level
         data_type: String
         description: "The engagement level of the learner with the subsection"

--- a/models/tags/schema.yml
+++ b/models/tags/schema.yml
@@ -6,13 +6,13 @@ models:
     columns:
       - name: course_key
         data_type: String
-        description: "The course key for the course"
+        description: '{{ doc("course_key") }}'
       - name: tag
         data_type: String
         description: "The name of the tag"
       - name: course_name
         data_type: String
-        description: "The name of the course"
+        description: '{{ doc("course_name") }}'
       - name: taxonomy_name
         data_type: String
         description: "The name of the parent taxonomy of the tag"
@@ -25,10 +25,10 @@ models:
     columns:
       - name: course_key
         data_type: String
-        description: "The course key for the course"
+        description: '{{ doc("course_key") }}'
       - name: course_name
         data_type: String
-        description: "The name of the course"
+        description: '{{ doc("course_name") }}'
       - name: tag_id
         data_type: String
         description: "The ID of the tag"
@@ -47,10 +47,10 @@ models:
     columns:
       - name: id
         data_type: Int32
-        description: "The record ID"
+        description: '{{ doc("id") }}'
       - name: object_id
         data_type: String
-        description: "The tagged object"
+        description: '{{ doc("object_id") }}'
       - name: taxonomy
         data_type: Int32
         description: "Foreign key to the taxonomy"
@@ -65,11 +65,11 @@ models:
         description: "Lineage data of the tag for parent tags"
 
   - name: most_recent_tags
-    description: "Latest object tags"
+    description: "Latest tags"
     columns:
       - name: id
         data_type: Int32
-        description: "The record ID"
+        description: '{{ doc("id") }}'
       - name: taxonomy
         data_type: Int32
         description: "Foreign key to the taxonomy"
@@ -87,11 +87,11 @@ models:
         description: "Lineage data of the tag for parent tags"
 
   - name: most_recent_taxonomies
-    description: "Latest object tags"
+    description: "Latest taxonomies"
     columns:
       - name: id
         data_type: Int32
-        description: "The record ID"
+        description: '{{ doc("id") }}'
       - name: name
-        data_type: Int32
+        data_type: String
         description: "Name for the taxonomy"

--- a/models/tags/sources.yml
+++ b/models/tags/sources.yml
@@ -6,31 +6,76 @@ sources:
     tables:
 
       - name: object_tag
+        description: '{{ doc("object_tag_source") }}'
         columns:
           - name: id
+            description: '{{ doc("id") }}'
+            type: Int32
           - name: object_id
+            description: '{{ doc("object_id") }}'
+            type: String
           - name: taxonomy
+            description: "Foreign key to the taxonomy"
+            type: Int32
           - name: tag
+            description: "The name of the tag"
+            type: String
           - name: _value
+            description: "Tag string"
+            type: String
           - name: _export_id
+            description: "Export ID"
+            type: String
           - name: lineage
+            description: "Lineage data of the tag for parent tags"
+            type: String
           - name: dump_id
+            description: '{{ doc("dump_id") }}'
+            type: UUID
           - name: time_last_dumped
+            description: '{{ doc("time_last_dumped") }}'
+            type: String
 
       - name: taxonomy
+        description: Taxonomy data from `post_save` Django signal on the Taxonomy model
         columns:
           - name: id
+            description: '{{ doc("id") }}'
+            type: Int32
           - name: name
+            description: "Name for the taxonomy"
+            type: String
           - name: dump_id
+            description: '{{ doc("dump_id") }}'
+            type: UUID
           - name: time_last_dumped
+            description: '{{ doc("time_last_dumped") }}'
+            type: String
 
       - name: tag
+        description: Tag data from `post_save` Django signal on the Tag model. Includes parent tag and lineage string for heirarchal relationships.
         columns:
           - name: id
+            description: '{{ doc("id") }}'
+            type: Int32
           - name: taxonomy
+            description: "Foreign key to the taxonomy"
+            type: Int32
           - name: parent
+            description: "Foreign key to the parent tag"
+            type: Int32
           - name: value
+            description: "Tag string"
+            type: String
           - name: external_id
+            description: "External ID"
+            type: String
           - name: lineage
+            description: "Lineage data of the tag for parent tags"
+            type: String
           - name: dump_id
+            description: '{{ doc("dump_id") }}'
+            type: UUID
           - name: time_last_dumped
+            description: '{{ doc("time_last_dumped") }}'
+            type: String

--- a/models/users/schema.yml
+++ b/models/users/schema.yml
@@ -13,13 +13,13 @@ models:
         description: "The external user id"
       - name: username
         data_type: String
-        description: "The username of the user"
+        description: '{{ doc("username") }}'
       - name: name
         data_type: String
-        description: "The name of the user"
+        description: '{{ doc("learner_name") }}'
       - name: email
         data_type: String
-        description: "The email of the user"
+        description: '{{ doc("email") }}'
 
   - name: dim_user_pii
     description: "A denormalized table of user PII information"
@@ -29,10 +29,10 @@ models:
         description: "The external user id"
       - name: username
         data_type: String
-        description: "The username"
+        description: '{{ doc("username") }}'
       - name: name
         data_type: String
-        description: "The name of the user"
+        description: '{{ doc("learner_name") }}'
       - name: email
         data_type: String
-        description: "The email of the user"
+        description: '{{ doc("email") }}'

--- a/models/users/sources.yml
+++ b/models/users/sources.yml
@@ -6,35 +6,89 @@ sources:
     tables:
 
       - name: user_profile
+        description: Users and associated data from `post_save` Django signal on the UserProfile model
         columns:
           - name: id
+            description: '{{ doc("id") }}'
+            type: String
           - name: user_id
+            description: "The user id"
+            type: String
           - name: name
+            description: '{{ doc("learner_name") }}'
+            type: String
           - name: username
+            description: '{{ doc("username") }}'
+            type: String
           - name: email
+            description: '{{ doc("email") }}'
+            type: String
           - name: meta
           - name: courseware
           - name: language
+            description: "The user's preferred language"
+            type: String
           - name: location
+            description: "The user's location"
+            type: String
           - name: year_of_birth
+            description: "The user's year of birth"
+            type: Int32
           - name: gender
+            description: "The user's gender"
+            type: String
           - name: level_of_education
+            description: "The user's level of education"
+            type: String
           - name: mailing_address
+            description: "The user's mailing address"
+            type: String
           - name: city
+            description: "The user's city"
+            type: String
           - name: country
+            description: "The user's country"
+            type: String
           - name: state
+            description: "The user's state"
+            type: String
           - name: goals
+            description: "The user's goals"
+            type: String
           - name: bio
+            description: "The user's bio"
+            type: String
           - name: profile_image_uploaded_at
+            description: "User's profile image upload date"
+            type: String
           - name: phone_number
+            description: "The user's phone number"
+            type: String
           - name: dump_id
+            description: '{{ doc("dump_id") }}'
+            type: UUID
           - name: time_last_dumped
+            description: '{{ doc("time_last_dumped") }}'
+            type: String
 
       - name: external_id
+        description: User ID with external id from `post_save` Django signal on the ExternalId model
         columns:
           - name: external_user_id
+            description: "The external user id"
+            type: String
           - name: external_id_type
+            description: "The type of external user id"
+            type: String
           - name: username
+            description: '{{ doc("username") }}'
+            type: String
           - name: user_id
+            description: "The user id"
+            type: String
           - name: dump_id
+            description: '{{ doc("dump_id") }}'
+            type: UUID
           - name: time_last_dumped
+            description: '{{ doc("time_last_dumped") }}'
+            type: String

--- a/models/video/schema.yml
+++ b/models/video/schema.yml
@@ -6,22 +6,22 @@ models:
     columns:
       - name: emission_time
         data_type: DateTime
-        description: "Timestamp, to the second, of when this event was emitted"
+        description: '{{ doc("emission_time") }}'
       - name: org
         data_type: String
-        description: "The organization that the course belongs to"
+        description: '{{ doc("org") }}'
       - name: course_key
         data_type: String
-        description: "The course key for the course"
+        description: '{{ doc("course_key") }}'
       - name: course_name
         data_type: String
-        description: "The name of the course"
+        description: '{{ doc("course_name") }}'
       - name: course_run
         data_type: String
-        description: "The course run for the course"
+        description: '{{ doc("course_run") }}'
       - name: video_id
         data_type: String
-        description: "The xAPI object identifier"
+        description: '{{ doc("object_id") }}'
       - name: video_name
         data_type: String
         description: "The name of the video"
@@ -33,10 +33,10 @@ models:
         description: "An anchor tag with a link to the video"
       - name: graded
         data_type: Boolean
-        description: "Whether the block is graded"
+        description: '{{ doc("graded") }}'
       - name: actor_id
         data_type: String
-        description: "The xAPI actor identifier"
+        description: '{{ doc("actor_id") }}'
       - name: video_duration
         data_type: Int64
         description: "The duration of the video in seconds"
@@ -48,47 +48,47 @@ models:
         description: "The percentile bucket for the video play event"
       - name: username
         data_type: String
-        description: "The username of the learner"
+        description: '{{ doc("username") }}'
       - name: name
         data_type: String
-        description: "The full name of the learner"
+        description: '{{ doc("learner_name") }}'
       - name: email
         data_type: String
-        description: "The email address of the learner"
+        description: '{{ doc("email") }}'
       - name: section_with_name
         data_type: string
-        description: "The name of the section this video belongs to, with section_number prepended"
+        description: '{{ doc("section_with_name") }}'
       - name: subsection_with_name
         data_type: string
-        description: "The name of the subsection this video belongs to, with subsection_number prepended"
+        description: '{{ doc("subsection_with_name") }}'
       - name: course_order
         data_type: Int32
-        description: "The sort order of this block in the course across all course blocks"
+        description: '{{ doc("course_order") }}'
 
   - name: video_playback_events
     description: "Events related to video playback"
     columns:
       - name: event_id
         data_type: uuid
-        description: "The unique identifier for the event"
+        description: '{{ doc("event_id") }}'
       - name: emission_time
         data_type: datetime
-        description: "The time the event was emitted"
+        description: '{{ doc("emission_time") }}'
       - name: actor_id
         data_type: string
-        description: "The xAPI actor identifier"
+        description: '{{ doc("actor_id") }}'
       - name: object_id
         data_type: string
-        description: "The xAPI object identifier"
+        description: '{{ doc("object_id") }}'
       - name: course_key
         data_type: string
-        description: "The course identifier"
+        description: '{{ doc("course_key") }}'
       - name: org
         data_type: string
-        description: "The organization that the course belongs to"
+        description: '{{ doc("org") }}'
       - name: verb_id
         data_type: string
-        description: "The xAPI verb identifier"
+        description: '{{ doc("verb_id") }}'
       - name: video_position
         data_type: decimal(9, 2)
         description: "The position in the video where the event occurred"
@@ -102,56 +102,56 @@ models:
     columns:
       - name: org
         data_type: string
-        description: "The organization that the course belongs to"
+        description: '{{ doc("org") }}'
       - name: course_key
         data_type: string
-        description: "The course key for the course"
+        description: '{{ doc("course_key") }}'
       - name: section_number
         data_type: string
-        description: "The location of this section in the course, represented as section:0:0"
+        description: '{{ doc("section_number") }}'
       - name: section_with_name
         data_type: string
-        description: "The name of the section this subsection belongs to, with section_number prepended"
+        description: '{{ doc("section_with_name") }}'
       - name: subsection_number
         data_type: string
-        description: "The location of this subsection in the course, represented as section:subsection:0"
+        description: '{{ doc("subsection_number") }}'
       - name: subsection_with_name
         data_type: string
-        description: "The name of the subsection, with section_number prepended"
+        description: '{{ doc("subsection_with_name") }}'
       - name: graded
         data_type: Boolean
-        description: "Whether the block is graded"
+        description: '{{ doc("graded") }}'
       - name: item_count
         data_type: uint64
         description: "The number of videos in this subsection"
       - name: course_order
         data_type: Int32
-        description: "The sort order of this block in the course across all course blocks"
+        description: '{{ doc("course_order") }}'
       - name: subsection_block_id
         data_type: string
-        description: "The unique identifier for the subsection block"
+        description: '{{ doc("subsection_block_id") }}'
       - name: section_block_id
         data_type: string
-        description: "The unique identifier for the section block"
+        description: '{{ doc("section_block_id") }}'
 
   - name: fact_video_engagement
     description: "A dataset with one record representing the engagement of a learner with a video"
     columns:
       - name: org
         data_type: string
-        description: "The organization that the video belongs to"
+        description: '{{ doc("org") }}'
       - name: course_key
         data_type: string
-        description: "The course key for the course"
+        description: '{{ doc("course_key") }}'
       - name: course_run
         data_type: String
-        description: "The course run for the course"
+        description: '{{ doc("course_run") }}'
       - name: section_with_name
         data_type: string
-        description: "The name of the section this subsection belongs to, with section_number prepended"
+        description: '{{ doc("section_with_name") }}'
       - name: subsection_with_name
         data_type: string
-        description: "The name of the subsection, with section_number prepended"
+        description: '{{ doc("subsection_with_name") }}'
       - name: section_subsection_name
         data_type: string
         description: "The name of the section or the subsection"
@@ -165,7 +165,7 @@ models:
                 - 'subsection'
       - name: actor_id
         data_type: string
-        description: "The xAPI actor identifier"
+        description: '{{ doc("actor_id") }}'
       - name: section_subsection_video_engagement
         data_type: string
         description: "The engagement level of the learner with the video"
@@ -177,13 +177,13 @@ models:
                 - 'All videos viewed'
       - name: username
         data_type: String
-        description: "The username of the learner"
+        description: '{{ doc("username") }}'
       - name: name
         data_type: String
-        description: "The full name of the learner"
+        description: '{{ doc("learner_name") }}'
       - name: email
         data_type: String
-        description: "The email address of the learner"
+        description: '{{ doc("email") }}'
 
 
   - name: section_video_engagement
@@ -191,16 +191,16 @@ models:
     columns:
       - name: org
         data_type: string
-        description: "The organization that the course belongs to"
+        description: '{{ doc("org") }}'
       - name: course_key
         data_type: string
-        description: "The course key for the course"
+        description: '{{ doc("course_key") }}'
       - name: actor_id
         data_type: string
-        description: "The xAPI actor identifier"
+        description: '{{ doc("actor_id") }}'
       - name: section_block_id
         data_type: string
-        description: "The unique identifier for the section block"
+        description: '{{ doc("section_block_id") }}'
       - name: engagement_level
         data_type: string
         description: "The engagement level of the learner with the section"
@@ -216,16 +216,16 @@ models:
     columns:
       - name: org
         data_type: string
-        description: "The organization that the course belongs to"
+        description: '{{ doc("org") }}'
       - name: course_key
         data_type: string
-        description: "The course key for the course"
+        description: '{{ doc("course_key") }}'
       - name: actor_id
         data_type: string
-        description: "The xAPI actor identifier"
+        description: '{{ doc("actor_id") }}'
       - name: subsection_block_id
         data_type: string
-        description: "The unique identifier for the subsection block"
+        description: '{{ doc("subsection_block_id") }}'
       - name: engagement_level
         data_type: string
         description: "The engagement level of the learner with the subsection"
@@ -241,13 +241,13 @@ models:
     columns:
       - name: org
         data_type: string
-        description: "The organization that the course belongs to"
+        description: '{{ doc("org") }}'
       - name: course_key
         data_type: string
-        description: "The course key for the course"
+        description: '{{ doc("course_key") }}'
       - name: actor_id
         data_type: string
-        description: "The xAPI actor identifier"
+        description: '{{ doc("actor_id") }}'
       - name: video_count
         data_type: Int32
         description: "Count of videos per course_key"


### PR DESCRIPTION
1. Add data types and descriptions to source files
2. Pull out descriptions for frequently used columns into separate file. This prevents the same columns having different descriptions.
<img width="1013" alt="image" src="https://github.com/user-attachments/assets/54ba3c03-7030-42a8-b6aa-2374815c7213" />
<img width="1013" alt="image" src="https://github.com/user-attachments/assets/1a18e71c-6fc1-4035-8036-1863494575a2" />
