### PR TITLE
chore: pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -24,9 +24,9 @@ jobs:
       id-token: "write"
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Setup Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.11.x"
       - name: Install dependencies

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -24,11 +24,11 @@ jobs:
       id-token: "write"
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           token: ${{ secrets.SEMANTIC_RELEASE_GITHUB_TOKEN }}
       - name: Setup Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.11.x"
       - name: Install dependencies
@@ -50,7 +50,7 @@ jobs:
           dbt docs generate
       - name: Deploy
         if: github.event_name == 'push'
-        uses: peaceiris/actions-gh-pages@v4
+        uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e # v4.0.0
         with:
           github_token: ${{ secrets.SEMANTIC_RELEASE_GITHUB_TOKEN }}
           publish_dir: ./target

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -9,9 +9,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Setup Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.11.x"
       - name: Install dependencies


### PR DESCRIPTION
## Summary

- Pins all pinnable GitHub Action \`uses:\` refs to full commit SHAs with human-readable version comments
- Generated using [pinact](https://github.com/suzuki-shunsuke/pinact) v3.10.0

## Context

Part of the org-wide SHA-pinning migration: openedx/.github#165

Reusable workflow calls (\`openedx/.github/.github/workflows/...@master\`) are intentionally left unpinned — they track the org's shared workflows by design.

## Test plan

- [ ] Confirm CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)\n\nResolves https://github.com/openedx/.github/issues/165